### PR TITLE
Fixed timer changes not being updated in UI

### DIFF
--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
 import 'main.dart';
 import 'native_timer_wrapper.dart';
 
@@ -102,7 +103,12 @@ class TimerState extends ChangeNotifier {
   }
 
   Future<void> startTimer(String exercise, Duration timerDuration) async {
-    final timer = nativeTimer.increaseDuration(timerDuration);
+    final timer = NativeTimerWrapper(
+      timerDuration,
+      Duration.zero,
+      DateTime.now(),
+      NativeTimerState.running,
+    );
     updateTimer(timer);
     await android.invokeMethod(
       'timer',

--- a/lib/timer_page.dart
+++ b/lib/timer_page.dart
@@ -30,6 +30,4 @@ class _TimerPageState extends State<TimerPage> {
       ),)
     );
   }
-
-
 }

--- a/lib/timer_progress_widgets.dart
+++ b/lib/timer_progress_widgets.dart
@@ -15,7 +15,11 @@ class TimerProgressIndicator extends StatelessWidget {
       return Visibility(
         visible: duration > Duration.zero,
         child: TweenAnimationBuilder(
-          tween: Tween<double>(begin: elapsed.inMilliseconds / duration.inMilliseconds, end: 1),
+          key: UniqueKey(),
+          tween: Tween<double>(
+            begin: elapsed.inMilliseconds / duration.inMilliseconds,
+            end: 1,
+          ),
           duration: remaining,
           builder: (context, value, child) => LinearProgressIndicator(
             value: value,
@@ -37,7 +41,11 @@ class TimerCircularProgressIndicator extends StatelessWidget {
       final remaining = timerState.nativeTimer.getRemaining();
       return duration > Duration.zero
           ? TweenAnimationBuilder(
-              tween: Tween<double>(begin: elapsed.inMilliseconds / duration.inMilliseconds, end: 1),
+              key: UniqueKey(),
+              tween: Tween<double>(
+                begin: elapsed.inMilliseconds / duration.inMilliseconds,
+                end: 1,
+              ),
               duration: remaining,
               builder: (context, value, child) =>
                   _TimerCircularProgressIndicatorTile(


### PR DESCRIPTION
I saw https://github.com/brandonp2412/Flexify/issues/5 and had a go testing the latest release build to see any issues.

While testing I noticed these bugs:
The timer UI gets out of sync if you start the time (+1 min), then save a set, the timer page would show the wrong remaining time.
If you save a set while another is in progress, it doesn't restart the timer.