### PR TITLE
Fixed IterableElementError.noElement() when no element in list

### DIFF
--- a/lib/exercise_list.dart
+++ b/lib/exercise_list.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:drift/drift.dart';
 import 'package:flexify/exercise_tile.dart';
 import 'package:flexify/main.dart';
@@ -23,8 +24,9 @@ class ExerciseList extends StatelessWidget {
       itemCount: planExercises.length,
       itemBuilder: (context, index) {
         final exercise = planExercises[index];
-        final gymSet = snapshot.data?.firstWhere(
-            (element) => element.read(database.gymSets.name) == exercise);
+        final gymSet = snapshot.data?.firstWhereOrNull(
+          (element) => element.read(database.gymSets.name) == exercise,
+        );
         var count = 0;
         if (gymSet != null) count = gymSet.read(database.gymSets.name.count())!;
         return ExerciseTile(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  collection: ^1.18.0
   drift: ^2.15.0
   sqlite3_flutter_libs: ^0.5.20
   path_provider: ^2.1.2


### PR DESCRIPTION
`.firstWhere()` src [here](https://github.com/dart-lang/sdk/blob/d243eb1254749fe67909a118c063449f9710872e/sdk/lib/core/iterable.dart#L697), throws an `IterableElementError.noElement()` if there isn't an element in the list.

As this only throws when the list is empty, it only occurs if one or more exercises in a plan have not been recorded before.