### PR TITLE
Automate screenshots

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -33,7 +33,7 @@ Function GenerateScreenshots{
   Start-Sleep -Seconds 30
 
   $env:FLEXIFY_DEVICE_TYPE="$deviceType"
-  flutter drive --driver=test_driver/integration_test.dart --target=integration_test/screenshot_test.dart --dart-define=FLEXIFY_DEVICE_TYPE=$deviceType -d $adbName
+  flutter drive --driver=test_driver/integration_test.dart --target=integration_test/screenshot_test.dart --dart-define=FLEXIFY_DEVICE_TYPE=$deviceType --profile -d $adbName
 
   Write-Output "Shutting down $deviceType"
   adb.exe -s $adbName reboot -p

--- a/integration_test/screenshot_test.dart
+++ b/integration_test/screenshot_test.dart
@@ -1,0 +1,279 @@
+import 'package:drift/drift.dart';
+import 'package:flexify/app_state.dart';
+import 'package:flexify/constants.dart';
+import 'package:flexify/database.dart';
+import 'package:flexify/main.dart' as app;
+import 'package:flexify/utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Map<String, double> exercisesToPopulateTestDB = {
+  "Barbell bench press": 90,
+  "Barbell bent-over row": 82.5,
+  "Barbell biceps curl": 45,
+  "Barbell shoulder press": 50,
+  "Chin-up": 20,
+  "Crunch": 25,
+  "Dumbbell bicep curls": 30,
+  "Dumbbell chest press": 55,
+  "Dumbbell lateral raise": 10,
+  "Dumbbell shoulder press": 40,
+};
+
+class SetInfo {
+  final DateTime dateTime;
+  final double reps;
+  final double weight;
+
+  SetInfo(int days, this.reps, this.weight)
+      : dateTime =
+            DateTime.now().subtract(Duration(days: days)).copyWith(hour: 12);
+}
+
+List<SetInfo> graphData = [
+  SetInfo(0, 8, 1),
+  SetInfo(0, 6, 5),
+  SetInfo(0, 6, 6.25),
+  SetInfo(4, 8, 1),
+  SetInfo(4, 6, 2.5),
+  SetInfo(4, 6, 5),
+  SetInfo(4, 6, 5),
+  SetInfo(4, 6, 5),
+  SetInfo(8, 6, 5),
+  SetInfo(8, 6, 4),
+  SetInfo(8, 6, 10),
+  SetInfo(12, 6, 5),
+  SetInfo(16, 6, 1),
+  SetInfo(20, 6, 5),
+  SetInfo(24, 6, 1),
+  SetInfo(28, 6, 1),
+  SetInfo(32, 6, 1),
+  SetInfo(36, 6, 1),
+];
+
+List<PlansCompanion> plans = [
+  PlansCompanion(
+    days: Value([weekdays[1], weekdays[5]].join(",")),
+    exercises: Value(
+        ["Triceps dip", " Squat", "Standing calf raise", "Pull-up"].join(",")),
+    title: const Value("Tuesday, Saturday"),
+  ),
+  PlansCompanion(
+    days: Value([weekdays[2], weekdays[6]].join(",")),
+    exercises: Value([
+      "Barbell bench press",
+      "Barbell bent-over row",
+      "Dumbbell lateral raise",
+      "Barbell biceps curl"
+    ].join(",")),
+    title: const Value("Wednesday, Sunday"),
+  ),
+  PlansCompanion(
+    days: Value(weekdays[0]),
+    exercises: Value([
+      "Barbell shoulder press",
+      "Crunch",
+      "Chin-up",
+      "Romanian deadlift"
+    ].join(",")),
+    title: const Value("Monday"),
+  ),
+  PlansCompanion(
+    days: Value(weekdays[3]),
+    exercises: Value([
+      "Barbell shoulder press",
+      "Neck curl",
+      "Chin-up",
+      "Romanian deadlift"
+    ].join(",")),
+    title: const Value("Thursday"),
+  ),
+];
+
+Future<void> appWrapper() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final settingsState = SettingsState();
+  await settingsState.init();
+  runApp(app.appProviders(settingsState));
+}
+
+Future<void> generateScreenshot({
+  required IntegrationTestWidgetsFlutterBinding binding,
+  required WidgetTester tester,
+  bool skipSettle = false,
+  Future<void> Function()? navigateToPage,
+}) async {
+  await appWrapper();
+  await tester.pump();
+  if (navigateToPage != null) await navigateToPage();
+  await binding.convertFlutterSurfaceToImage();
+  if (!skipSettle)
+    await tester.pumpAndSettle();
+  else
+    await tester.pump();
+  await binding.takeScreenshot(tester.testDescription);
+}
+
+GymSetsCompanion generateGymSetCompanion(String exercise, double weight,
+        {double reps = 12, DateTime? date}) =>
+    GymSetsCompanion.insert(
+      name: exercise,
+      reps: reps,
+      weight: weight,
+      unit: "kg",
+      created: date ?? DateTime.now(),
+    );
+
+Future<void> navigateToGraphPage(WidgetTester tester) async => await tester.tap(
+      find.byIcon(Icons.insights),
+    );
+
+Future<void> navigateToTricepsDips(WidgetTester tester) async {
+  await tester.dragUntilVisible(
+      find.text("Triceps dip"), find.byType(ListView), const Offset(0, 10));
+  await tester.pump();
+  await tester.tap(find.widgetWithText(ListTile, "Triceps dip"));
+}
+
+Future<void> navigateToViewGraphPage(WidgetTester tester) async {
+  await navigateToGraphPage(tester);
+  await tester.pumpAndSettle();
+  await navigateToTricepsDips(tester);
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding binding =
+      IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await requestNotificationPermission();
+    await Permission.ignoreBatteryOptimizations.request();
+    await Permission.scheduleExactAlarm.request();
+
+    app.db = AppDatabase();
+    app.android = const MethodChannel("com.presley.flexify/android");
+
+    await app.db.delete(app.db.gymSets).go();
+    await app.db.delete(app.db.plans).go();
+
+    exercisesToPopulateTestDB.forEach(
+      (key, value) async => await app.db.into(app.db.gymSets).insert(
+            generateGymSetCompanion(key, value),
+          ),
+    );
+
+    for (final element in graphData) {
+      await app.db.into(app.db.gymSets).insert(
+            generateGymSetCompanion("Triceps dip", element.weight,
+                reps: element.reps, date: element.dateTime),
+          );
+    }
+
+    for (var element in plans) {
+      await app.db.into(app.db.plans).insert(element);
+    }
+
+    SharedPreferences.setMockInitialValues({
+      "themeMode": "ThemeMode.system",
+      "showReorder": true,
+      "resetTimers": true,
+      "showUnits": true,
+      "dateFormat": "yyyy-MM-dd h:mm a",
+      "timerDuration": const Duration(minutes: 3, seconds: 30).inMilliseconds,
+    });
+  });
+
+  group("Generate phoneScreenshots", () {
+    testWidgets(
+      "PlanPage",
+      (tester) async => await generateScreenshot(
+        binding: binding,
+        tester: tester,
+      ),
+    );
+    testWidgets(
+      "GraphPage",
+      (tester) async => await generateScreenshot(
+        binding: binding,
+        tester: tester,
+        navigateToPage: () async => await navigateToGraphPage(tester),
+      ),
+    );
+    testWidgets(
+      "SettingsPage",
+      (tester) async => await generateScreenshot(
+        binding: binding,
+        tester: tester,
+        navigateToPage: () async => await tester.tap(
+          find.byIcon(Icons.settings),
+        ),
+      ),
+    );
+    testWidgets(
+      "ViewGraphPage",
+      (tester) async => await generateScreenshot(
+        binding: binding,
+        tester: tester,
+        navigateToPage: () async => await navigateToViewGraphPage(tester),
+      ),
+    );
+    testWidgets(
+      "GraphHistory",
+      (tester) async => await generateScreenshot(
+        binding: binding,
+        tester: tester,
+        navigateToPage: () async {
+          await navigateToViewGraphPage(tester);
+          await tester.pump();
+          await tester.tap(find.byIcon(Icons.history));
+        },
+      ),
+    );
+    testWidgets(
+      "EditPlanPage",
+      (tester) async => await generateScreenshot(
+        binding: binding,
+        tester: tester,
+        navigateToPage: () async {
+          await tester.tap(find.byIcon(Icons.add));
+        },
+      ),
+    );
+    testWidgets(
+      "TimerPage",
+      (tester) async => await generateScreenshot(
+        binding: binding,
+        tester: tester,
+        skipSettle: true,
+        navigateToPage: () async {
+          await tester.tap(find.byIcon(Icons.more_vert));
+          await tester.pumpAndSettle();
+          await tester.tap(find.byIcon(Icons.timer));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text("+1 min"));
+          await tester.pump(const Duration(seconds: 7));
+        },
+      ),
+    );
+    testWidgets(
+      "StartPlanPage",
+      (tester) async => await generateScreenshot(
+        binding: binding,
+        tester: tester,
+        navigateToPage: () async {
+          await tester.pump();
+          await tester.tap(
+            find.widgetWithText(
+              ListTile,
+              plans.first.exercises.value.split(",").join(", "),
+            ),
+          );
+        },
+      ),
+    );
+  });
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flexify/timer_progress_widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+
 import 'app_state.dart';
 import 'plans_page.dart';
 
@@ -20,16 +21,16 @@ Future<void> main() async {
   final settingsState = SettingsState();
   await settingsState.init();
 
-  runApp(
-    MultiProvider(
+  runApp(appProviders(settingsState));
+}
+
+Widget appProviders(SettingsState settingsState) => MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (context) => settingsState),
         ChangeNotifierProvider(create: (context) => TimerState()),
       ],
       child: const App(),
-    ),
-  );
-}
+    );
 
 class App extends StatelessWidget {
   const App({super.key});
@@ -43,22 +44,22 @@ class App extends StatelessWidget {
         seedColor: Colors.deepPurple, brightness: Brightness.dark);
 
     return DynamicColorBuilder(
-        builder: (lightDynamic, darkDynamic) => MaterialApp(
-              title: 'Flexify',
-              theme: ThemeData(
-                colorScheme:
-                    settings.systemColors ? lightDynamic : defaultTheme,
-                fontFamily: 'Manrope',
-                useMaterial3: true,
-              ),
-              darkTheme: ThemeData(
-                colorScheme: settings.systemColors ? darkDynamic : defaultDark,
-                fontFamily: 'Manrope',
-                useMaterial3: true,
-              ),
-              themeMode: settings.themeMode,
-              home: const HomePage(),
-            ));
+      builder: (lightDynamic, darkDynamic) => MaterialApp(
+        title: 'Flexify',
+        theme: ThemeData(
+          colorScheme: settings.systemColors ? lightDynamic : defaultTheme,
+          fontFamily: 'Manrope',
+          useMaterial3: true,
+        ),
+        darkTheme: ThemeData(
+          colorScheme: settings.systemColors ? darkDynamic : defaultDark,
+          fontFamily: 'Manrope',
+          useMaterial3: true,
+        ),
+        themeMode: settings.themeMode,
+        home: const HomePage(),
+      ),
+    );
   }
 }
 

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -19,6 +19,7 @@ DateTime parseDate(String dateString) {
 }
 
 Future<bool> requestNotificationPermission() async {
+  if (const String.fromEnvironment("FLEXIFY_DEVICE_TYPE").isNotEmpty) return true;
   final permission = await Permission.notification.request();
   return permission.isGranted;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,8 @@ dependencies:
   sqlite3: ^2.4.0
 
 dev_dependencies:
+  integration_test:
+    sdk: flutter
   flutter_test:
     sdk: flutter
 

--- a/test_driver/integration_test.dart
+++ b/test_driver/integration_test.dart
@@ -1,0 +1,12 @@
+import 'dart:io';
+import 'package:integration_test/integration_test_driver_extended.dart';
+
+Future<void> main() async => await integrationDriver(
+      onScreenshot: (name, image, [args]) async {
+        final imgFile =
+            await File('screenshots/$name.png').create(recursive: true);
+        await imgFile.writeAsBytes(image);
+        return true;
+      },
+      writeResponseOnFailure: true,
+    );

--- a/test_driver/integration_test.dart
+++ b/test_driver/integration_test.dart
@@ -3,8 +3,10 @@ import 'package:integration_test/integration_test_driver_extended.dart';
 
 Future<void> main() async => await integrationDriver(
       onScreenshot: (name, image, [args]) async {
+        final deviceType = Platform.environment["FLEXIFY_DEVICE_TYPE"];
+        if (deviceType == null || deviceType.isEmpty) throw "FLEXIFY_DEVICE_TYPE must be set, so integration driver knows where to save screenshots.";
         final imgFile =
-            await File('screenshots/$name.png').create(recursive: true);
+            await File('android/fastlane/metadata/android/en-US/images/$deviceType/$name.png').create(recursive: true);
         await imgFile.writeAsBytes(image);
         return true;
       },


### PR DESCRIPTION
Solves https://github.com/brandonp2412/Flexify/issues/9.

As mentioned in above issue this works by running on the 3 different emulators of the required size.

You **MUST** have these emulators created with these names in order for the updated script to run.
![image](https://github.com/brandonp2412/Flexify/assets/56293291/22d9a0f2-7b46-48be-b05d-3a74f097945c)

In order to match the current image sizes 1 to 1, they need to be set up with the following sizes or you could choose any size as long as the names are right.
`phoneScreenshots = 1080x2400`
`sevenInchScreenshots = 1920x1080`
`tenInchScreenshots = 2560x1600`


I suggest before first running the script you open each of the 3 emulators and customize the theme - e.g. dark mode / light mode and the color theme, so its probably best to be on a higher version of android.

Different android theme example:  

<img src="https://github.com/brandonp2412/Flexify/assets/56293291/a06c7227-f2f0-4a5b-9337-2abccc795be4" width="200" />
<img src="https://github.com/brandonp2412/Flexify/assets/56293291/895de3e4-bb07-40d8-a4ab-8b2c1b3d8d11" width="200" />

I did test this on one of my windows vm as I assume that is the platform this is going to be run on and it did work on there aswell, but let me know if you have any issues running it.

Additionally you may be able to reduce the time delay in the script, I had it set quite high as I was running a emulator inside a virtual machine.

Right now all the different sizes generate the same screenshots, just in different sizes and themes and only `phoneScreenshots` generates an extra 4.
However I added `const deviceType` in `screenshot_test.dart` `main()` so if there needs to be more variation, content and state can be conditionally changed.

`featureGraphic.png` is not automatically updated because it will probably be easier to use a command line tool than to stitch the produced images together in dart code.