### PR TITLE
feat: implement custom set indicator to replace progress bar

### DIFF
--- a/lib/custom_set_indicator.dart
+++ b/lib/custom_set_indicator.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class CustomSetIndicator extends StatelessWidget {
+  const CustomSetIndicator({
+    super.key,
+    required this.index,
+    required this.count,
+    required this.firstRender,
+  });
+  final int index;
+  final int count;
+  final bool firstRender;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(2),
+          color: Theme.of(context).colorScheme.outlineVariant,
+        ),
+        height: 6,
+        child: AnimatedFractionallySizedBox(
+          widthFactor: count > index ? 1 : 0,
+          duration: Duration(milliseconds: firstRender ? 0 : 250),
+          curve: Curves.ease,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(2),
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/custom_set_indicator.dart
+++ b/lib/custom_set_indicator.dart
@@ -3,35 +3,44 @@ import 'package:flutter/material.dart';
 class CustomSetIndicator extends StatelessWidget {
   const CustomSetIndicator({
     super.key,
-    required this.index,
     required this.count,
     required this.firstRender,
+    required this.max,
   });
-  final int index;
   final int count;
+  final int max;
   final bool firstRender;
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: Container(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(2),
-          color: Theme.of(context).colorScheme.outlineVariant,
-        ),
-        height: 6,
-        child: AnimatedFractionallySizedBox(
-          widthFactor: count > index ? 1 : 0,
-          duration: Duration(milliseconds: firstRender ? 0 : 250),
-          curve: Curves.ease,
-          child: DecoratedBox(
+    List<Widget> children = [];
+    for (int i = 0; i < max; i++) {
+      children.add(
+        Expanded(
+          child: Container(
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(2),
-              color: Theme.of(context).colorScheme.primary,
+              color: Theme.of(context).colorScheme.outlineVariant,
+            ),
+            height: 6,
+            child: AnimatedFractionallySizedBox(
+              widthFactor: count > i ? 1 : 0,
+              duration: Duration(milliseconds: firstRender ? 0 : 250),
+              curve: Curves.ease,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(2),
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+              ),
             ),
           ),
         ),
-      ),
-    );
+      );
+      if (i < max - 1) {
+        children.add(const SizedBox(width: 6));
+      }
+    }
+    return Row(children: children);
   }
 }

--- a/lib/plan/exercise_list.dart
+++ b/lib/plan/exercise_list.dart
@@ -89,20 +89,6 @@ class ExerciseList extends StatelessWidget {
       max = counts![countIndex].maxSets ?? maxSets;
     }
 
-    var setIndicators = <Widget>[];
-    for (int i = 0; i < max; i++) {
-      setIndicators.add(
-        CustomSetIndicator(
-          index: i,
-          count: count,
-          firstRender: firstRender,
-        ),
-      );
-      if (i < max - 1) {
-        setIndicators.add(const SizedBox(width: 6));
-      }
-    }
-
     Widget trailing = const SizedBox();
     switch (planTrailing) {
       case PlanTrailing.reorder:
@@ -176,9 +162,7 @@ class ExerciseList extends StatelessWidget {
               ],
             ),
           ),
-          Row(
-            children: setIndicators,
-          ),
+          CustomSetIndicator(count: count, max: max, firstRender: firstRender),
         ],
       ),
     );

--- a/lib/plan/exercise_list.dart
+++ b/lib/plan/exercise_list.dart
@@ -1,4 +1,5 @@
 import 'package:flexify/constants.dart';
+import 'package:flexify/custom_set_indicator.dart';
 import 'package:flexify/database/database.dart';
 import 'package:flexify/database/gym_sets.dart';
 import 'package:flexify/main.dart';
@@ -88,6 +89,20 @@ class ExerciseList extends StatelessWidget {
       max = counts![countIndex].maxSets ?? maxSets;
     }
 
+    var setIndicators = <Widget>[];
+    for (int i = 0; i < max; i++) {
+      setIndicators.add(
+        CustomSetIndicator(
+          index: i,
+          count: count,
+          firstRender: firstRender,
+        ),
+      );
+      if (i < max - 1) {
+        setIndicators.add(const SizedBox(width: 6));
+      }
+    }
+
     Widget trailing = const SizedBox();
     switch (planTrailing) {
       case PlanTrailing.reorder:
@@ -161,15 +176,8 @@ class ExerciseList extends StatelessWidget {
               ],
             ),
           ),
-          TweenAnimationBuilder(
-            tween: Tween<double>(
-              begin: (count / max) - 1,
-              end: count / max,
-            ),
-            duration: Duration(milliseconds: firstRender ? 0 : 150),
-            builder: (context, value, child) => LinearProgressIndicator(
-              value: value,
-            ),
+          Row(
+            children: setIndicators,
           ),
         ],
       ),

--- a/lib/plan/exercise_tile.dart
+++ b/lib/plan/exercise_tile.dart
@@ -72,16 +72,18 @@ class _ExerciseTileState extends State<ExerciseTile> {
                         keyboardType: const TextInputType.numberWithOptions(
                           decimal: false,
                         ),
-                        onTap: () => selectAll(maxSets),
                         onChanged: (value) {
-                          final pe = widget.planExercise.copyWith(
-                            enabled: const Value(true),
-                            maxSets: Value(int.tryParse(maxSets.text)),
-                          );
-                          widget.onChange(pe);
+                          if (int.parse(maxSets.text) > 0 &&
+                              int.parse(maxSets.text) <= 20) {
+                            final pe = widget.planExercise.copyWith(
+                              enabled: const Value(true),
+                              maxSets: Value(int.parse(maxSets.text)),
+                            );
+                            widget.onChange(pe);
+                          }
                         },
                         decoration: InputDecoration(
-                          labelText: "Maximum sets",
+                          labelText: "Working sets (max: 20)",
                           border: const OutlineInputBorder(),
                           hintText: value.toString(),
                         ),

--- a/lib/plan/exercise_tile.dart
+++ b/lib/plan/exercise_tile.dart
@@ -72,6 +72,7 @@ class _ExerciseTileState extends State<ExerciseTile> {
                         keyboardType: const TextInputType.numberWithOptions(
                           decimal: false,
                         ),
+                        onTap: () => selectAll(maxSets),
                         onChanged: (value) {
                           if (int.parse(maxSets.text) > 0 &&
                               int.parse(maxSets.text) <= 20) {

--- a/lib/settings/settings_workout.dart
+++ b/lib/settings/settings_workout.dart
@@ -39,15 +39,19 @@ List<Widget> getWorkouts(
         child: TextField(
           controller: maxSets,
           decoration: const InputDecoration(
-            labelText: 'Sets per exercise',
+            labelText: 'Sets per exercise (max: 20)',
           ),
           keyboardType: const TextInputType.numberWithOptions(decimal: false),
           onTap: () => selectAll(maxSets),
-          onChanged: (value) => db.settings.update().write(
-                SettingsCompanion(
-                  maxSets: Value(int.parse(value)),
-                ),
-              ),
+          onChanged: (value) {
+            if (int.parse(value) > 0 && int.parse(value) <= 20) {
+              db.settings.update().write(
+                    SettingsCompanion(
+                      maxSets: Value(int.parse(value)),
+                    ),
+                  );
+            }
+          },
         ),
       ),
     if ('plan trailing display'.contains(term.toLowerCase()))


### PR DESCRIPTION
This PR replaces the current LinearProgressIndicator used in the plan page to keep track of sets with a custom animated widget that's segmented for each set. The main purpose is to communicate more clearly what the set amount is for each exercise when just looking at the plan. It also has a more satisfying animation than LinearProgressIndicator which hopefully can improve exercise adherence slightly 

![flexify_screenshot1](https://github.com/user-attachments/assets/7b6695dd-6d11-45aa-af12-00481eae091a)

closes #81 