### PR TITLE
add muscle group filter to graphs page

### DIFF
--- a/lib/database/gym_sets.dart
+++ b/lib/database/gym_sets.dart
@@ -197,6 +197,7 @@ Stream<List<GymSetsCompanion>> watchGraphs() {
           db.gymSets.distance,
           db.gymSets.created.max(),
           db.gymSets.image,
+          db.gymSets.category,
         ])
         ..orderBy([
           OrderingTerm(
@@ -219,6 +220,7 @@ Stream<List<GymSetsCompanion>> watchGraphs() {
                 distance: Value(result.read(db.gymSets.distance)!),
                 created: Value(result.read(db.gymSets.created.max())!),
                 image: Value(result.read(db.gymSets.image)),
+                category: Value(result.read(db.gymSets.category)),
               ),
             )
             .toList(),

--- a/lib/graph/graphs_page.dart
+++ b/lib/graph/graphs_page.dart
@@ -5,6 +5,7 @@ import 'package:flexify/database/database.dart';
 import 'package:flexify/database/gym_sets.dart';
 import 'package:flexify/graph/add_exercise_page.dart';
 import 'package:flexify/graph/edit_graph_page.dart';
+import 'package:flexify/graphs_filters.dart';
 import 'package:flexify/main.dart';
 import 'package:flexify/plan/plan_state.dart';
 import 'package:flexify/utils.dart';
@@ -29,6 +30,7 @@ class GraphsPageState extends State<GraphsPage>
   final Set<String> selected = {};
   final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
   String search = '';
+  String? category;
 
   @override
   bool get wantKeepAlive => true;
@@ -63,12 +65,25 @@ class GraphsPageState extends State<GraphsPage>
           final gymSets = snapshot.data!.where((gymSet) {
             final name = gymSet.name.value.toLowerCase();
             final searchText = search.toLowerCase();
-            return name.contains(searchText);
+            if (category != null) {
+              return gymSet.category.value == category &&
+                  name.contains(searchText);
+            } else {
+              return name.contains(searchText);
+            }
           }).toList();
 
           return material.Column(
             children: [
               AppSearch(
+                filter: GraphsFilters(
+                  category: category,
+                  setCategory: (value) {
+                    setState(() {
+                      category = value;
+                    });
+                  },
+                ),
                 onShare: () async {
                   final selCopy = selected.toList();
                   setState(() {

--- a/lib/graphs_filters.dart
+++ b/lib/graphs_filters.dart
@@ -1,0 +1,63 @@
+import 'package:flexify/constants.dart';
+import 'package:flutter/material.dart';
+
+class GraphsFilters extends StatefulWidget {
+  final String? category;
+  final Function(String?) setCategory;
+
+  const GraphsFilters({
+    super.key,
+    required this.category,
+    required this.setCategory,
+  });
+
+  @override
+  createState() => _GraphsFiltersState();
+}
+
+class _GraphsFiltersState extends State<GraphsFilters> {
+  int get filtersCount => (widget.category != null ? 1 : 0);
+
+  @override
+  Widget build(BuildContext context) {
+    return Badge.count(
+      count: filtersCount,
+      isLabelVisible: filtersCount > 0,
+      backgroundColor: Theme.of(context).colorScheme.primary,
+      child: PopupMenuButton(
+        itemBuilder: (context) => [
+          PopupMenuItem(
+            child: DropdownButtonFormField(
+              decoration: const InputDecoration(labelText: 'Category'),
+              value: widget.category,
+              items: categories
+                  .map(
+                    (category) => DropdownMenuItem(
+                      value: category,
+                      child: Text(category),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (value) {
+                widget.setCategory(value);
+                Navigator.pop(context);
+              },
+            ),
+          ),
+          PopupMenuItem(
+            child: ListTile(
+              leading: const Icon(Icons.clear_all),
+              title: const Text("Clear"),
+              onTap: () async {
+                widget.setCategory(null);
+                Navigator.pop(context);
+              },
+            ),
+          ),
+        ],
+        tooltip: "Filter",
+        icon: const Icon(Icons.filter_list),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This PR adds the ability to filter entries in the graphs page by muscle group. This can make it easier to compare performance by muscle group or help pick exercises from the list if you know what muscle group you want. 

Can of course be expanded to include more filters in the future, e.g. cardio/strength