### PR TITLE
Fix exercise images not being removed

### DIFF
--- a/lib/graph/edit_graph_page.dart
+++ b/lib/graph/edit_graph_page.dart
@@ -234,7 +234,7 @@ class _EditGraphPageState extends State<EditGraphPage> {
         cardio: Value.absentIfNull(cardio),
         unit: Value.absentIfNull(unit),
         restMs: Value(duration?.inMilliseconds),
-        image: Value.absentIfNull(image),
+        image: Value(image),
         category: Value.absentIfNull(category),
       ),
     );


### PR DESCRIPTION
A one-liner to fix exercise images not being deleted on long press. This gives `image` a `null` value instead of trying to make it absent when deleting an image, since drift doesn't seem to write absent values to the database. 

I don't know much about database stuff so there might be a better solution, but from my quick testing this works fine.

Resolves #105 