### PR TITLE
Add new compact day selector to edit plan page

### DIFF
--- a/lib/day_selector.dart
+++ b/lib/day_selector.dart
@@ -18,12 +18,14 @@ class _DaySelectorState extends State<DaySelector> {
         Expanded(
           child: TweenAnimationBuilder<Color?>(
             tween: ColorTween(
-              begin: Theme.of(context).colorScheme.surface,
+              begin: widget.daySwitches[i]
+                  ? Theme.of(context).colorScheme.primary
+                  : Theme.of(context).colorScheme.surfaceContainer,
               end: widget.daySwitches[i]
                   ? Theme.of(context).colorScheme.primary
-                  : Theme.of(context).colorScheme.surface,
+                  : Theme.of(context).colorScheme.surfaceContainer,
             ),
-            duration: const Duration(milliseconds: 200),
+            duration: const Duration(milliseconds: 150),
             curve: Curves.ease,
             builder: (BuildContext context, Color? color, Widget? child) {
               return TextButton(
@@ -31,7 +33,7 @@ class _DaySelectorState extends State<DaySelector> {
                   shape: const WidgetStatePropertyAll(
                     CircleBorder(),
                   ),
-                  minimumSize: const WidgetStatePropertyAll(Size(55, 55)),
+                  minimumSize: const WidgetStatePropertyAll(Size(54, 54)),
                   shadowColor: WidgetStatePropertyAll(
                     Theme.of(context).colorScheme.shadow,
                   ),
@@ -52,8 +54,8 @@ class _DaySelectorState extends State<DaySelector> {
                   style: TextStyle(
                     color: widget.daySwitches[i]
                         ? Theme.of(context).colorScheme.onPrimary
-                        : Colors.white,
-                    fontSize: 16.0,
+                        : Theme.of(context).colorScheme.inverseSurface,
+                    fontSize: 14.0,
                   ),
                 ),
               );

--- a/lib/day_selector.dart
+++ b/lib/day_selector.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flexify/constants.dart';
+
+class DaySelector extends StatefulWidget {
+  final List<bool> daySwitches;
+  const DaySelector({super.key, required this.daySwitches});
+
+  @override
+  State<DaySelector> createState() => _DaySelectorState();
+}
+
+class _DaySelectorState extends State<DaySelector> {
+  @override
+  Widget build(BuildContext context) {
+    List<Widget> children = [];
+    for (int i = 0; i < weekdays.length; i++) {
+      children.add(
+        Expanded(
+          child: TweenAnimationBuilder<Color?>(
+            tween: ColorTween(
+              begin: Theme.of(context).colorScheme.surface,
+              end: widget.daySwitches[i]
+                  ? Theme.of(context).colorScheme.primary
+                  : Theme.of(context).colorScheme.surface,
+            ),
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.ease,
+            builder: (BuildContext context, Color? color, Widget? child) {
+              return TextButton(
+                style: ButtonStyle(
+                  shape: const WidgetStatePropertyAll(
+                    CircleBorder(),
+                  ),
+                  minimumSize: const WidgetStatePropertyAll(Size(55, 55)),
+                  shadowColor: WidgetStatePropertyAll(
+                    Theme.of(context).colorScheme.shadow,
+                  ),
+                  elevation: const WidgetStatePropertyAll(4.0),
+                  backgroundColor: WidgetStatePropertyAll(color),
+                ),
+                onPressed: () {
+                  setState(() {
+                    widget.daySwitches[i]
+                        ? widget.daySwitches[i] = false
+                        : widget.daySwitches[i] = true;
+                  });
+                },
+                child: Text(
+                  weekdays[i].length < 3
+                      ? weekdays[i]
+                      : weekdays[i].substring(0, 3),
+                  style: TextStyle(
+                    color: widget.daySwitches[i]
+                        ? Theme.of(context).colorScheme.onPrimary
+                        : Colors.white,
+                    fontSize: 16.0,
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+    }
+    return Row(children: children);
+  }
+}

--- a/lib/plan/edit_plan_page.dart
+++ b/lib/plan/edit_plan_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:drift/drift.dart';
 import 'package:flexify/constants.dart';
 import 'package:flexify/database/database.dart';
+import 'package:flexify/day_selector.dart';
 import 'package:flexify/graph/add_exercise_page.dart';
 import 'package:flexify/main.dart';
 import 'package:flexify/plan/exercise_tile.dart';
@@ -87,19 +88,7 @@ class _EditPlanPageState extends State<EditPlanPage> {
             const SizedBox(
               height: 16.0,
             ),
-            Text('Days', style: Theme.of(context).textTheme.headlineSmall),
-            ...List.generate(
-              7,
-              (index) => SwitchListTile(
-                title: Text(weekdays[index]),
-                value: daySwitches[index],
-                onChanged: (value) {
-                  setState(() {
-                    daySwitches[index] = value;
-                  });
-                },
-              ),
-            ),
+            DaySelector(daySwitches: daySwitches),
             material.Padding(
               padding: const EdgeInsets.all(8.0),
               child: SearchBar(

--- a/lib/plan/edit_plan_page.dart
+++ b/lib/plan/edit_plan_page.dart
@@ -89,6 +89,8 @@ class _EditPlanPageState extends State<EditPlanPage> {
               height: 16.0,
             ),
             DaySelector(daySwitches: daySwitches),
+            const SizedBox(height: 16.0),
+            const material.Divider(),
             material.Padding(
               padding: const EdgeInsets.all(8.0),
               child: SearchBar(


### PR DESCRIPTION
This PR adds a new day selector to the edit plan page that aims to be more compact and visually appealing

![flexify_screenshot2](https://github.com/user-attachments/assets/b4ceb69c-d071-4e79-b344-e553707dff65)

![flexify_screenshot3](https://github.com/user-attachments/assets/586051bc-ccfe-4528-a9e9-3577d3eaf54c)
