### PR TITLE
Improve plan day selector

### DIFF
--- a/lib/day_selector.dart
+++ b/lib/day_selector.dart
@@ -71,6 +71,9 @@ class _DaySelectorState extends State<DaySelector> {
           },
         ),
       );
+      if (i < weekdays.length - 1) {
+        children.add(const SizedBox(width: 4));
+      }
     }
 
     return Row(

--- a/lib/day_selector.dart
+++ b/lib/day_selector.dart
@@ -34,7 +34,7 @@ class _DaySelectorState extends State<DaySelector> {
                   shape: const WidgetStatePropertyAll(
                     CircleBorder(),
                   ),
-                  minimumSize: const WidgetStatePropertyAll(Size(54, 54)),
+                  minimumSize: const WidgetStatePropertyAll(Size(48, 48)),
                   padding: const WidgetStatePropertyAll(EdgeInsets.zero),
                   shadowColor: WidgetStatePropertyAll(
                     Theme.of(context).colorScheme.shadow,

--- a/lib/day_selector.dart
+++ b/lib/day_selector.dart
@@ -25,7 +25,7 @@ class _DaySelectorState extends State<DaySelector> {
                 ? Theme.of(context).colorScheme.primary
                 : Theme.of(context).colorScheme.surfaceContainer,
           ),
-          duration: const Duration(milliseconds: 150),
+          duration: const Duration(milliseconds: 200),
           curve: Curves.ease,
           builder: (BuildContext context, Color? color, Widget? child) {
             return Expanded(

--- a/lib/day_selector.dart
+++ b/lib/day_selector.dart
@@ -16,26 +16,26 @@ class _DaySelectorState extends State<DaySelector> {
 
     for (int i = 0; i < weekdays.length; i++) {
       children.add(
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: TweenAnimationBuilder<Color?>(
-            tween: ColorTween(
-              begin: widget.daySwitches[i]
-                  ? Theme.of(context).colorScheme.primary
-                  : Theme.of(context).colorScheme.surfaceContainer,
-              end: widget.daySwitches[i]
-                  ? Theme.of(context).colorScheme.primary
-                  : Theme.of(context).colorScheme.surfaceContainer,
-            ),
-            duration: const Duration(milliseconds: 150),
-            curve: Curves.ease,
-            builder: (BuildContext context, Color? color, Widget? child) {
-              return TextButton(
+        TweenAnimationBuilder<Color?>(
+          tween: ColorTween(
+            begin: widget.daySwitches[i]
+                ? Theme.of(context).colorScheme.primary
+                : Theme.of(context).colorScheme.surfaceContainer,
+            end: widget.daySwitches[i]
+                ? Theme.of(context).colorScheme.primary
+                : Theme.of(context).colorScheme.surfaceContainer,
+          ),
+          duration: const Duration(milliseconds: 150),
+          curve: Curves.ease,
+          builder: (BuildContext context, Color? color, Widget? child) {
+            return Expanded(
+              child: TextButton(
                 style: ButtonStyle(
                   shape: const WidgetStatePropertyAll(
                     CircleBorder(),
                   ),
                   minimumSize: const WidgetStatePropertyAll(Size(54, 54)),
+                  padding: const WidgetStatePropertyAll(EdgeInsets.zero),
                   shadowColor: WidgetStatePropertyAll(
                     Theme.of(context).colorScheme.shadow,
                   ),
@@ -49,24 +49,33 @@ class _DaySelectorState extends State<DaySelector> {
                         : widget.daySwitches[i] = true;
                   });
                 },
-                child: Text(
-                  weekdays[i].length < 3
-                      ? weekdays[i]
-                      : weekdays[i].substring(0, 3),
-                  style: TextStyle(
-                    color: widget.daySwitches[i]
-                        ? Theme.of(context).colorScheme.onPrimary
-                        : Theme.of(context).colorScheme.inverseSurface,
-                    fontSize: 14.0,
+                child: Padding(
+                  padding: const EdgeInsets.all(4.0),
+                  child: FittedBox(
+                    fit: BoxFit.contain,
+                    child: Text(
+                      weekdays[i].length < 3
+                          ? weekdays[i]
+                          : weekdays[i].substring(0, 3),
+                      style: TextStyle(
+                        color: widget.daySwitches[i]
+                            ? Theme.of(context).colorScheme.onPrimary
+                            : Theme.of(context).colorScheme.inverseSurface,
+                        fontSize: 14.0,
+                      ),
+                    ),
                   ),
                 ),
-              );
-            },
-          ),
+              ),
+            );
+          },
         ),
       );
     }
 
-    return Wrap(children: children);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: children,
+    );
   }
 }


### PR DESCRIPTION
My original PR for this was bad, sorry. I didn't test properly for smaller screens. This should make the day selector look how I originally intended. The buttons spread to the available space, and if there isn't enough space they scale down, no clipping or wrapping. Tested on my phone and looks good

![flexify_4](https://github.com/user-attachments/assets/1af0aa87-cb2f-4f78-8c89-209b7e16cdf1)

![flexify_5](https://github.com/user-attachments/assets/aacd1371-5c24-4a5d-82de-2483a10bf7ac)

