### PR TITLE
Make set progress bars fade

### DIFF
--- a/lib/custom_set_indicator.dart
+++ b/lib/custom_set_indicator.dart
@@ -17,23 +17,16 @@ class CustomSetIndicator extends StatelessWidget {
     for (int i = 0; i < max; i++) {
       children.add(
         Expanded(
-          child: Container(
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 250),
+            curve: Curves.ease,
             decoration: BoxDecoration(
+              color: count > i
+                  ? Theme.of(context).colorScheme.primary
+                  : Theme.of(context).colorScheme.outlineVariant,
               borderRadius: BorderRadius.circular(2),
-              color: Theme.of(context).colorScheme.outlineVariant,
             ),
             height: 6,
-            child: AnimatedFractionallySizedBox(
-              widthFactor: count > i ? 1 : 0,
-              duration: Duration(milliseconds: firstRender ? 0 : 250),
-              curve: Curves.ease,
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(2),
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-              ),
-            ),
           ),
         ),
       );


### PR DESCRIPTION
Small design change to make the set progress bars fade in and out instead of whatever they are doing currently. I think a simple fade looks better for our purposes. Feel free to close if you disagree of course