### PR TITLE
Fix reps and weight being 0 when entering plan page

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1114,10 +1114,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR fixes a bug with a database query retrieving the wrong rows, making the app set initial weight and reps to 0 instead of the values of the last set when entering the plan page. Currently it retrieves the FIRST row of each exercise (which always has 0 weight and reps), so this PR makes it get the latest set. 

fixes #123 