### PR TITLE
Handle edge case on Automated Backups

### DIFF
--- a/android/app/src/main/kotlin/com/presley/flexify/BackupReceiver.kt
+++ b/android/app/src/main/kotlin/com/presley/flexify/BackupReceiver.kt
@@ -31,6 +31,12 @@ class BackupReceiver : BroadcastReceiver() {
 
         val backupUri = Uri.parse(backupPath)
 
+        val dir = DocumentFile.fromTreeUri(context, backupUri)
+        if (dir == null) return;
+
+        val fileName = generateBackupFileName()
+        if (dir.findFile(fileName) != null) return; /* backup already been done */
+
         val channelId = "backup_channel"
         var notificationBuilder = NotificationCompat.Builder(context, channelId)
             .setSmallIcon(R.drawable.baseline_arrow_downward_24)
@@ -55,12 +61,7 @@ class BackupReceiver : BroadcastReceiver() {
             return
         }
 
-        val dir = DocumentFile.fromTreeUri(context, backupUri)
-        val currentDate = LocalDate.now() // Get today's date
-        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd") // Define the pattern
-        val yyyyMMdd = formatter.format(currentDate)
-        val fileName = "flexify-${yyyyMMdd}.sqlite"
-        val file = dir!!.createFile("application/x-sqlite3", fileName)!!
+        val file = dir.createFile("application/x-sqlite3", fileName)!!
         Log.d("BackupReceiver", "file.uri=${file.uri}")
         notificationBuilder = notificationBuilder.setContentText(file.name)
 
@@ -95,5 +96,12 @@ class BackupReceiver : BroadcastReceiver() {
                 notificationManager.notify(2, notificationBuilder.build())
             }
         }
+    }
+
+    private fun generateBackupFileName(): String {
+        val currentDate = LocalDate.now()
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        val yyyyMMdd = formatter.format(currentDate)
+        return "flexify-${yyyyMMdd}.sqlite"
     }
 }

--- a/android/app/src/main/kotlin/com/presley/flexify/utils.kt
+++ b/android/app/src/main/kotlin/com/presley/flexify/utils.kt
@@ -25,6 +25,7 @@ fun scheduleBackups(context: Context) {
         set(Calendar.SECOND, 0)
         if (timeInMillis < System.currentTimeMillis()) {
             add(Calendar.DAY_OF_YEAR, 1)
+            pendingIntent.send()
         }
     }
 


### PR DESCRIPTION
Currently automated backups in the following way:

```
if (time is earlier than 2am today) {
    schedule for 2 am today
} else {
    schedule for 2 am tomorrow
}
```

The problem with this is if someone has automated power off / turns their phone off over night.

If the phone is off within the 2am period then no backup will be done.
When the phone is turned on (after 2am), the application will schedule the backup for the next day.
This means that no backups ever end up being done.

The changes below modify the logic as such: 

```
if (time is earlier than 2am today) {
    schedule for 2 am today
} else {
    schedule for 2 am tomorrow
    if (backup for today not done) {
         backupNow()
    }
}
```

Fixing missing backups.
