### PR TITLE
Feat; more dynamic search

### DIFF
--- a/lib/graph/graphs_page.dart
+++ b/lib/graph/graphs_page.dart
@@ -164,7 +164,7 @@ class GraphsPageState extends State<GraphsPage>
 
           for (final term in searchTerms) {
             snapshotStream = snapshotStream
-              .where((gymSet) => gymSet.name.value.contains(term));
+              .where((gymSet) => gymSet.name.value.toLowerCase().contains(term));
           }
 
           final gymSets = snapshotStream.toList();

--- a/lib/graph/graphs_page.dart
+++ b/lib/graph/graphs_page.dart
@@ -152,16 +152,22 @@ class GraphsPageState extends State<GraphsPage>
           if (!snapshot.hasData) return const SizedBox();
           if (snapshot.hasError) return ErrorWidget(snapshot.error.toString());
 
-          final gymSets = snapshot.data!.where((gymSet) {
-            final name = gymSet.name.value.toLowerCase();
-            final searchText = search.toLowerCase();
-            if (category != null) {
-              return gymSet.category.value == category &&
-                  name.contains(searchText);
-            } else {
-              return name.contains(searchText);
-            }
-          }).toList();
+          final searchTerms = search.toLowerCase().split(" ")
+            .where((term) => !term.isEmpty);
+          var snapshotStream = snapshot.data!
+            .where((gymSet) {
+              if (category != null) {
+                return gymSet.category.value == category;
+              }
+              return true;
+            });
+
+          for (final term in searchTerms) {
+            snapshotStream = snapshotStream
+              .where((gymSet) => gymSet.name.value.contains(term));
+          }
+
+          final gymSets = snapshotStream.toList();
 
           return material.Column(
             children: [

--- a/lib/plan/plans_page.dart
+++ b/lib/plan/plans_page.dart
@@ -64,14 +64,25 @@ class _PlansPageWidgetState extends State<_PlansPageWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final searchTerms = search.toLowerCase().split(" ")
+            .where((term) => !term.isEmpty);
+    List<Plan>? filtered;
     planState = context.watch<PlanState>();
-    final filtered = planState?.plans
-        .where(
-          (element) =>
-              element.days.toLowerCase().contains(search.toLowerCase()) ||
-              element.exercises.toLowerCase().contains(search.toLowerCase()),
-        )
-        .toList();
+
+
+    if (planState != null) {
+      Iterable<Plan> planPartialFilter = planState!.plans;
+  
+      for (final term in searchTerms) {
+        planPartialFilter = planPartialFilter
+          .where(
+            (element) =>
+                element.days.toLowerCase().contains(term.toLowerCase()) ||
+                element.exercises.toLowerCase().contains(term.toLowerCase()),
+          );
+      }
+      filtered = planPartialFilter.toList();
+    }
 
     return Scaffold(
       body: Column(

--- a/lib/sets/edit_set_page.dart
+++ b/lib/sets/edit_set_page.dart
@@ -432,11 +432,15 @@ class _EditSetPageState extends State<EditSetPage> {
   material.Autocomplete<String> autocomplete(bool showBodyWeight) {
     return Autocomplete<String>(
       optionsBuilder: (textEditingValue) {
-        return nameOptions.where(
-          (option) => option
-              .toLowerCase()
-              .contains(textEditingValue.text.toLowerCase()),
-        );
+        final searchTerms = textEditingValue.text.toLowerCase().split(" ")
+            .where((term) => !term.isEmpty);
+        Iterable<String> options = nameOptions;
+
+        for (final term in searchTerms) {
+          options = options
+            .where((option) => option.toLowerCase().contains(term));
+        }
+        return options;
       },
       onSelected: (option) => onSelected(option, showBodyWeight),
       initialValue: TextEditingValue(text: name),

--- a/lib/sets/history_page.dart
+++ b/lib/sets/history_page.dart
@@ -340,15 +340,13 @@ class _HistoryPageWidgetState extends State<_HistoryPageWidget> {
                 mode: OrderingMode.desc,
               ),
         ],
-      ));
+      )
+      ..where((tbl) => tbl.hidden.equals(false))
+      ..limit(limit));
 
     for (final term in searchTerms) {
       query = query..where((tbl) => tbl.name.contains(term));
     }
-    
-    query = (query
-      ..where((tbl) => tbl.hidden.equals(false))
-      ..limit(limit));
 
     if (category != null)
       query = query..where((tbl) => tbl.category.equals(category!));

--- a/lib/sets/history_page.dart
+++ b/lib/sets/history_page.dart
@@ -329,6 +329,9 @@ class _HistoryPageWidgetState extends State<_HistoryPageWidget> {
   }
 
   void setStream() {
+    final searchTerms = search.toLowerCase().split(" ")
+      .where((term) => !term.isEmpty);
+
     var query = (db.gymSets.select()
       ..orderBy(
         [
@@ -337,8 +340,13 @@ class _HistoryPageWidgetState extends State<_HistoryPageWidget> {
                 mode: OrderingMode.desc,
               ),
         ],
-      )
-      ..where((tbl) => tbl.name.contains(search.toLowerCase()))
+      ));
+
+    for (final term in searchTerms) {
+      query = query..where((tbl) => tbl.name.contains(term));
+    }
+    
+    query = (query
       ..where((tbl) => tbl.hidden.equals(false))
       ..limit(limit));
 


### PR DESCRIPTION
This merge adds a more dynamic keyword based search. This would allow one to write entries differently to find them. Motivation for this is that I usually mess up the orientation of the words when searching for them and this change allows one to search both "curl leg" or "seat leg" to find the "Leg curl seated", in turn
 making it faster to find


| Where | New behaviour |
|-------|---------------|
|   History tab    |        ![Screenshot_20250628_110351](https://github.com/user-attachments/assets/c8ff5985-9cb7-45d4-95b0-22fd90c62242)       |
|   Add set    |        ![image](https://github.com/user-attachments/assets/57012410-d623-470f-98c2-8ee7784af15a)  |
|  Graphs tab     |    ![Screenshot_20250628_111006](https://github.com/user-attachments/assets/0d852bd0-3e6a-4078-b87d-d5f683bea46d)           |
|  Planner tab      |           ![Screenshot_20250628_111259](https://github.com/user-attachments/assets/adf3ab51-965e-4b13-9eb1-6ce2599dd911)    |



