### PR TITLE
Fix dcl via memory error on GrapheneOS by switching to sqflite

### DIFF
--- a/lib/database/database_connection_native.dart
+++ b/lib/database/database_connection_native.dart
@@ -1,26 +1,11 @@
-import 'dart:io';
-
 import 'package:drift/drift.dart';
-import 'package:drift/native.dart';
+import 'package:drift_sqflite/drift_sqflite.dart';
 import 'package:flutter/foundation.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
-import 'package:sqlite3/sqlite3.dart';
-import 'package:sqlite3_flutter_libs/sqlite3_flutter_libs.dart';
 
 LazyDatabase createNativeConnection() {
   return LazyDatabase(() async {
-    final folder = await getApplicationDocumentsDirectory();
-    final file = File(p.join(folder.path, 'flexify.sqlite'));
-
-    if (Platform.isAndroid) {
-      await applyWorkaroundToOpenSqlite3OnOldAndroidVersions();
-    }
-
-    final cache = (await getTemporaryDirectory()).path;
-    sqlite3.tempDirectory = cache;
-    return NativeDatabase.createInBackground(
-      file,
+    return SqfliteQueryExecutor.inDatabaseFolder(
+      path: 'flexify.sqlite',
       logStatements: kDebugMode,
     );
   });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.2
   drift: ^2.28.1
-  sqlite3_flutter_libs: ^0.5.39
   path_provider: ^2.1.2
   path: ^1.8.3
   csv: ^6.0.0
@@ -18,7 +17,8 @@ dependencies:
   permission_handler: ^12.0.1
   provider: ^6.1.1
   dynamic_color: ^1.7.0
-  sqlite3: ^2.4.0
+  drift_sqflite: ^2.0.1
+  sqflite: ^2.4.2
   file_picker: ^10.2.0
   share_plus: ^11.0.0
   audioplayers: ^6.5.0


### PR DESCRIPTION
This pull request switches the database backend from `NativeDatabase` to `SqfliteQueryExecutor` to resolve crashes on security-hardened operating systems.

Closes #149