### PR TITLE
fix issue #206 by updating the way exercises are stored and splitted

### DIFF
--- a/lib/graph/graphs_page.dart
+++ b/lib/graph/graphs_page.dart
@@ -80,7 +80,7 @@ class GraphsPageState extends State<GraphsPage>
 
     final plans = await db.plans.select().get();
     for (final plan in plans) {
-      final exercises = plan.exercises.split(',');
+      final exercises = plan.exercises.split('~');
       exercises.removeWhere(
         (exercise) => copy.contains(exercise),
       );

--- a/lib/plan/edit_plan_page.dart
+++ b/lib/plan/edit_plan_page.dart
@@ -193,7 +193,7 @@ class _EditPlanPageState extends State<EditPlanPage> {
       exercises: exercises
           .where((element) => element.enabled.value)
           .map((element) => element.exercise.value)
-          .join(','),
+          .join('~'),
       title: Value(titleCtrl.text),
     );
 

--- a/lib/plan/plan_tile.dart
+++ b/lib/plan/plan_tile.dart
@@ -101,7 +101,7 @@ class PlanTile extends StatelessWidget {
       ),
       child: ListTile(
         title: title,
-        subtitle: Text(plan.exercises.split(',').join(', ')),
+        subtitle: Text(plan.exercises.split('~').join(', ')),
         leading: leading,
         trailing: Builder(
           builder: (context) {

--- a/lib/plan/start_plan_page.dart
+++ b/lib/plan/start_plan_page.dart
@@ -45,7 +45,7 @@ class _StartPlanPageState extends State<StartPlanPage>
   String? category;
   String? image;
 
-  late List<String> exercises = widget.plan.exercises.split(',');
+  late List<String> exercises = widget.plan.exercises.split('~');
   late PlanState planState = context.read<PlanState>();
   late String unit = context.read<SettingsState>().value.strengthUnit;
   late String title = widget.plan.days.replaceAll(",", ", ");
@@ -416,7 +416,7 @@ class _StartPlanPageState extends State<StartPlanPage>
     if (index == -1) return Navigator.pop(context);
 
     final plan = planState.plans[index];
-    final split = plan.exercises.split(',');
+    final split = plan.exercises.split('~');
 
     if (!mounted) return;
     setState(() {

--- a/lib/plan/swap_workout.dart
+++ b/lib/plan/swap_workout.dart
@@ -119,7 +119,7 @@ class _SwapWorkoutState extends State<SwapWorkout> {
                               ..where((tbl) => tbl.id.equals(widget.planId)))
                             .getSingle();
 
-                        final exercisesList = plan.exercises.split(',');
+                        final exercisesList = plan.exercises.split('~');
                         final oldExerciseIndex =
                             exercisesList.indexOf(widget.exercise);
 


### PR DESCRIPTION
This PR fixes a bug with the way the exercises under a plan are split and displayed on the start plan page.

fixes https://github.com/brandonp2412/Flexify/issues/206

Preview:
1) Exercise:
<img width="530" height="460" alt="image" src="https://github.com/user-attachments/assets/59b2b698-eadf-4173-9c2a-316a0b7ef55a" />

2) Plan preview:
<img width="556" height="679" alt="image" src="https://github.com/user-attachments/assets/bbca3f3d-e703-4df1-b7f7-5afce06d6d59" />