### PR TITLE
Add temp sorting to graph page

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -31,6 +31,12 @@ enum StrengthMetric {
   bestReps,
 }
 
+enum GraphSort {
+  dateDesc,
+  dateAsc,
+  name,
+}
+
 final defaultSettings = SettingsCompanion.insert(
   themeMode: ThemeMode.system.toString(),
   planTrailing: PlanTrailing.reorder.toString(),

--- a/lib/graph/graphs_page.dart
+++ b/lib/graph/graphs_page.dart
@@ -44,6 +44,7 @@ class GraphsPageState extends State<GraphsPage>
   final scroll = ScrollController();
   bool extendFab = true;
   int total = 0;
+  GraphSort sort = GraphSort.dateDesc;
 
   @override
   bool get wantKeepAlive => true;
@@ -165,7 +166,27 @@ class GraphsPageState extends State<GraphsPage>
           }
 
           final gymSets = stream.toList();
+          switch (sort) {
+            case GraphSort.dateDesc:
+              gymSets.sort(
+                    (a, b) => b.created.value.compareTo(a.created.value),
+              );
+              break;
 
+            case GraphSort.dateAsc:
+              gymSets.sort(
+                    (a, b) => a.created.value.compareTo(b.created.value),
+              );
+              break;
+
+            case GraphSort.name:
+              gymSets.sort(
+                    (a, b) => a.name.value.toLowerCase().compareTo(
+                  b.name.value.toLowerCase(),
+                ),
+              );
+              break;
+          }
           return material.Column(
             children: [
               AppSearch(
@@ -174,6 +195,12 @@ class GraphsPageState extends State<GraphsPage>
                   setCategory: (value) {
                     setState(() {
                       category = value;
+                    });
+                  },
+                  sort: sort,
+                  setSort: (value) {
+                    setState(() {
+                      sort = value;
                     });
                   },
                 ),
@@ -381,16 +408,15 @@ class GraphsPageState extends State<GraphsPage>
         final set = gymSets.elementAtOrNull(currentIdx);
         if (set == null) return const SizedBox();
 
-        final prev = currentIdx > 0 ? gymSets[currentIdx - 1] : null;
+        final previousItem = currentIdx > 0 ? gymSets[currentIdx - 1] : set;
 
-        final created = prev?.created.value.toLocal();
-
-        final divider =
-            created != null && !isSameDay(created, set.created.value);
+        final bool showDivider =
+            sort != GraphSort.name
+                && (currentIdx == 0 || !isSameDay(set.created.value.toLocal(), previousItem.created.value.toLocal()));
 
         return material.Column(
           children: [
-            if (divider)
+            if (showDivider)
               material.Row(
                 children: [
                   const material.Expanded(child: Divider()),
@@ -399,7 +425,7 @@ class GraphsPageState extends State<GraphsPage>
                   Selector<SettingsState, String>(
                     selector: (p0, p1) => p1.value.shortDateFormat,
                     builder: (context, format, child) =>
-                        Text(DateFormat(format).format(created)),
+                        Text(DateFormat(format).format(set.created.value.toLocal())),
                   ),
                   const SizedBox(width: 4),
                   const material.Expanded(child: Divider()),

--- a/lib/graph/graphs_page.dart
+++ b/lib/graph/graphs_page.dart
@@ -169,21 +169,21 @@ class GraphsPageState extends State<GraphsPage>
           switch (sort) {
             case GraphSort.dateDesc:
               gymSets.sort(
-                    (a, b) => b.created.value.compareTo(a.created.value),
+                (a, b) => b.created.value.compareTo(a.created.value),
               );
               break;
 
             case GraphSort.dateAsc:
               gymSets.sort(
-                    (a, b) => a.created.value.compareTo(b.created.value),
+                (a, b) => a.created.value.compareTo(b.created.value),
               );
               break;
 
             case GraphSort.name:
               gymSets.sort(
-                    (a, b) => a.name.value.toLowerCase().compareTo(
-                  b.name.value.toLowerCase(),
-                ),
+                (a, b) => a.name.value.toLowerCase().compareTo(
+                      b.name.value.toLowerCase(),
+                    ),
               );
               break;
           }
@@ -408,15 +408,17 @@ class GraphsPageState extends State<GraphsPage>
         final set = gymSets.elementAtOrNull(currentIdx);
         if (set == null) return const SizedBox();
 
-        final previousItem = currentIdx > 0 ? gymSets[currentIdx - 1] : set;
+        final prev = currentIdx > 0 ? gymSets[currentIdx - 1] : null;
 
-        final bool showDivider =
-            sort != GraphSort.name
-                && (currentIdx == 0 || !isSameDay(set.created.value.toLocal(), previousItem.created.value.toLocal()));
+        final created = prev?.created.value.toLocal();
+
+        final divider = sort != GraphSort.name &&
+            created != null &&
+            !isSameDay(created, set.created.value);
 
         return material.Column(
           children: [
-            if (showDivider)
+            if (divider)
               material.Row(
                 children: [
                   const material.Expanded(child: Divider()),
@@ -425,7 +427,7 @@ class GraphsPageState extends State<GraphsPage>
                   Selector<SettingsState, String>(
                     selector: (p0, p1) => p1.value.shortDateFormat,
                     builder: (context, format, child) =>
-                        Text(DateFormat(format).format(set.created.value.toLocal())),
+                        Text(DateFormat(format).format(created)),
                   ),
                   const SizedBox(width: 4),
                   const material.Expanded(child: Divider()),

--- a/lib/graphs_filters.dart
+++ b/lib/graphs_filters.dart
@@ -1,14 +1,21 @@
 import 'package:flexify/database/gym_sets.dart';
 import 'package:flutter/material.dart';
 
+import 'constants.dart';
+
 class GraphsFilters extends StatefulWidget {
   final String? category;
   final Function(String?) setCategory;
+
+  final GraphSort sort;
+  final Function(GraphSort) setSort;
 
   const GraphsFilters({
     super.key,
     required this.category,
     required this.setCategory,
+    required this.sort,
+    required this.setSort,
   });
 
   @override
@@ -16,7 +23,9 @@ class GraphsFilters extends StatefulWidget {
 }
 
 class _GraphsFiltersState extends State<GraphsFilters> {
-  int get count => (widget.category != null ? 1 : 0);
+  int get count =>
+      (widget.category != null ? 1 : 0) +
+          (widget.sort != GraphSort.dateDesc ? 1 : 0);
 
   @override
   Widget build(BuildContext context) {
@@ -28,18 +37,48 @@ class _GraphsFiltersState extends State<GraphsFilters> {
         stream: categoriesStream,
         builder: (context, snapshot) {
           return PopupMenuButton(
+            tooltip: "Filter",
+            icon: const Icon(Icons.filter_list),
             itemBuilder: (context) => [
               PopupMenuItem(
-                child: DropdownButtonFormField(
+                enabled: false,
+                child: DropdownButtonFormField<GraphSort>(
+                  decoration: const InputDecoration(labelText: 'Sort by'),
+                  value: widget.sort,
+                  items: const [
+                    DropdownMenuItem(
+                      value: GraphSort.dateDesc,
+                      child: Text('Date (newest)'),
+                    ),
+                    DropdownMenuItem(
+                      value: GraphSort.dateAsc,
+                      child: Text('Date (oldest)'),
+                    ),
+                    DropdownMenuItem(
+                      value: GraphSort.name,
+                      child: Text('Name'),
+                    ),
+                  ],
+                  onChanged: (value) {
+                    if (value == null) return;
+                    widget.setSort(value);
+                    Navigator.pop(context);
+                  },
+                ),
+              ),
+
+              PopupMenuItem(
+                enabled: false,
+                child: DropdownButtonFormField<String>(
                   decoration: const InputDecoration(labelText: 'Category'),
                   value: widget.category,
                   items: snapshot.data
                       ?.map(
                         (category) => DropdownMenuItem(
-                          value: category,
-                          child: Text(category),
-                        ),
-                      )
+                      value: category,
+                      child: Text(category),
+                    ),
+                  )
                       .toList(),
                   onChanged: (value) {
                     widget.setCategory(value);
@@ -47,22 +86,23 @@ class _GraphsFiltersState extends State<GraphsFilters> {
                   },
                 ),
               ),
+
               PopupMenuItem(
                 child: ListTile(
                   leading: const Icon(Icons.clear),
                   title: const Text("Clear"),
-                  onTap: () async {
+                  onTap: () {
                     widget.setCategory(null);
+                    widget.setSort(GraphSort.dateDesc);
                     Navigator.pop(context);
                   },
                 ),
               ),
             ],
-            tooltip: "Filter",
-            icon: const Icon(Icons.filter_list),
           );
         },
       ),
     );
   }
+
 }


### PR DESCRIPTION
Added sort option into the Filter menu in Graphs page. 
Allows user to change sorting and pick from;
Date Ascending
Date Descending
Name. 

Permanency follows filter permanency logic. 

Also incorporated Divider Date logic from [previous PR ](https://github.com/brandonp2412/Flexify/pull/272) into this page when sorted by date (divider is removed when sorted by name)