### PR TITLE
fix: refresh plan exercise streams after database import

### DIFF
--- a/lib/import_data.dart
+++ b/lib/import_data.dart
@@ -136,6 +136,7 @@ $version
 
     await sourceFile.copy(p.join(dbFolder.path, 'flexify.sqlite'));
     db = AppDatabase();
+    dbVersion.value++;
 
     await (db.settings.update())
         .write(const SettingsCompanion(alarmSound: Value('')));

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,6 +39,11 @@ Future<void> main() async {
 
 AppDatabase db = AppDatabase();
 
+/// Bumped whenever [db] is replaced with a new instance (e.g. after
+/// importing a database), so widgets holding a `.watch()` stream tied to
+/// the old instance know to rebuild it against the current one.
+final ValueNotifier<int> dbVersion = ValueNotifier(0);
+
 MethodChannel androidChannel =
     const MethodChannel("com.presley.flexify/android");
 

--- a/lib/plan/plan_tile.dart
+++ b/lib/plan/plan_tile.dart
@@ -38,6 +38,17 @@ class _PlanTileState extends State<PlanTile> {
   void initState() {
     super.initState();
     _exercisesStream = _getExercises();
+    dbVersion.addListener(_onDbChanged);
+  }
+
+  @override
+  void dispose() {
+    dbVersion.removeListener(_onDbChanged);
+    super.dispose();
+  }
+
+  void _onDbChanged() {
+    setState(() => _exercisesStream = _getExercises());
   }
 
   Stream<List<PlanExercise>> _getExercises() {

--- a/lib/plan/start_plan_page.dart
+++ b/lib/plan/start_plan_page.dart
@@ -375,6 +375,7 @@ class _StartPlanPageState extends State<StartPlanPage>
 
     WidgetsBinding.instance.removeObserver(this);
     planState.removeListener(planChanged);
+    dbVersion.removeListener(_loadExercises);
     _gymSetsSub?.cancel();
 
     super.dispose();
@@ -428,6 +429,7 @@ class _StartPlanPageState extends State<StartPlanPage>
     super.initState();
     planState.addListener(planChanged);
     WidgetsBinding.instance.addObserver(this);
+    dbVersion.addListener(_loadExercises);
 
     planState = context.read<PlanState>();
     title = widget.plan.title?.isNotEmpty == true


### PR DESCRIPTION
- Importing a database closes the old AppDatabase and swaps in a new
  instance, but PlanTile and StartPlanPage cache a Drift .watch()
  stream built once against whichever instance was current at
  initState. Those streams never receive further updates once the old
  instance is closed, so plan exercises stayed blank until the app was
  restarted (#315).
- Add a dbVersion notifier bumped whenever db is replaced, and have
  both widgets rebuild their exercise streams when it changes.