### PR TITLE
fix: capture commit_sha from the correct step in release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
     outputs:
       version: ${{ steps.bump.outputs.version }}
       build_number: ${{ steps.bump.outputs.build_number }}
-      commit_sha: ${{ steps.bump.outputs.commit_sha }}
+      commit_sha: ${{ steps.commit-push.outputs.commit_sha }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -112,6 +112,7 @@ jobs:
           cp "$CHANGELOG_FILE" "assets/changelogs/$(date +%s).txt"
 
       - name: Commit and push version bump
+        id: commit-push
         run: |
           git add pubspec.yaml fastlane/metadata assets/changelogs
           git commit -m "Release ${{ steps.bump.outputs.version }} [skip ci]"


### PR DESCRIPTION
## Summary
- The `version-bump` job's `commit_sha` output referenced `steps.bump.outputs.commit_sha`, but `bump` is the id of the "Bump versions and generate changelog" step, which only sets `version`/`build_number`. The actual `echo "commit_sha=$(git rev-parse HEAD)"` runs in the next step, "Commit and push version bump", which had **no `id:`** at all — so that output was always unreachable/empty.
- With `ref: ''`, `actions/checkout` falls back to `github.sha`, i.e. the commit that *triggered* the workflow — one commit before the version bump. Every downstream job (`build-android`, `build-linux`, `build-windows`, web deploy, `create-github-release`, `deploy-windows-store`) has therefore been building from the pre-bump commit, and every release tag has pointed one commit behind the actual "Release X" commit.
- Verified against real history: tags `2.1.97` through `2.1.101` all point to the parent of their "Release X" commit (5 for 5), matching the "it seems the tags are always behind the version bump commit" report on #314.
- Fix: add `id: commit-push` to the "Commit and push version bump" step and reference `steps.commit-push.outputs.commit_sha` for the job's `commit_sha` output.

This should also help with F-Droid's reproducible-build verification, since their recipe builds from the tagged commit expecting it to match the exact source used for the published artifact.

Fixes #314

## Test plan
- [ ] YAML validated with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/main.yml'))"`
- [ ] Watch the next push to `main` to confirm the created tag points at the "Release X" commit itself (not its parent), and that build jobs check out that same commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MMDGwfPBdE2hLLvBDKZMLK)_