### PR TITLE
feat: warn on low-accuracy one rep max estimates

### DIFF
--- a/lib/graph/strength_page.dart
+++ b/lib/graph/strength_page.dart
@@ -314,6 +314,40 @@ class _StrengthPageState extends State<StrengthPage> {
                   _savePreferences();
                 },
               ),
+              if (metric == StrengthMetric.oneRepMax &&
+                  data.any((row) => row.reps >= 10))
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.errorContainer,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Row(
+                      children: [
+                        Icon(
+                          Icons.warning_amber_rounded,
+                          color: theme.colorScheme.onErrorContainer,
+                          size: 20,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            'One rep max estimates are less accurate for '
+                            'sets of 10+ reps',
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onErrorContainer,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
               const SizedBox(height: 8),
               Expanded(
                 child: data.isEmpty


### PR DESCRIPTION
- Show a banner on the strength graph when the One rep max metric is
  selected and any visible set used 10+ reps, since Epley/Brzycki-style
  estimates degrade significantly at higher rep counts