### PR TITLE
feat: add timed rep and isometric exercise tracking (e.g. Plank)

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -533,10 +533,13 @@ class AppDatabase extends _$AppDatabase {
             ),
           );
         },
+        from55To56: (Migrator m, Schema56 schema) async {
+          await m.addColumn(schema.gymSets, schema.gymSets.repDuration);
+        },
       ),
     );
   }
 
   @override
-  int get schemaVersion => 55;
+  int get schemaVersion => 56;
 }

--- a/lib/database/gym_sets.dart
+++ b/lib/database/gym_sets.dart
@@ -426,6 +426,7 @@ class GymSets extends Table {
   TextColumn get notes => text().nullable()();
   IntColumn get planId => integer().nullable()();
   RealColumn get reps => real()();
+  RealColumn get repDuration => real().withDefault(const Constant(0.0))();
   IntColumn get restMs => integer().nullable()();
   TextColumn get unit => text()();
   RealColumn get weight => real()();

--- a/lib/sets/edit_set_page.dart
+++ b/lib/sets/edit_set_page.dart
@@ -29,6 +29,7 @@ class EditSetPage extends StatefulWidget {
 
 class _EditSetPageState extends State<EditSetPage> {
   final reps = TextEditingController();
+  final repDuration = TextEditingController();
   final weight = TextEditingController();
   final orm = TextEditingController();
   final body = TextEditingController();
@@ -226,10 +227,30 @@ class _EditSetPageState extends State<EditSetPage> {
   List<Widget> buildStrengthFields() {
     return [
       const SizedBox(height: 8.0),
-      if (name != 'Weight') ...[buildRepsField(), const SizedBox(height: 8.0)],
+      if (name != 'Weight') ...[
+        buildRepsField(),
+        const SizedBox(height: 8.0),
+        buildRepDurationField(),
+        const SizedBox(height: 8.0),
+      ],
       buildWeightField(),
       if (name != 'Weight') ...[const SizedBox(height: 8.0), buildORMField()],
     ];
+  }
+
+  Widget buildRepDurationField() {
+    return StepperField(
+      controller: repDuration,
+      labelText: 'Time per rep (seconds)',
+      step: 5,
+      textInputAction: TextInputAction.next,
+      onFieldSubmitted: (_) => selectAll(weight),
+      validator: (value) {
+        if (value == null || value.isEmpty) return null;
+        if (double.tryParse(value) == null) return 'Invalid number';
+        return null;
+      },
+    );
   }
 
   Widget buildRepsField() {
@@ -580,6 +601,7 @@ class _EditSetPageState extends State<EditSetPage> {
   @override
   void dispose() {
     reps.dispose();
+    repDuration.dispose();
     repsNode.dispose();
     weight.dispose();
     body.dispose();
@@ -621,17 +643,23 @@ class _EditSetPageState extends State<EditSetPage> {
   Future<void> save() async {
     if (!key.currentState!.validate()) return;
 
+    final parsedRepDuration = double.tryParse(repDuration.text) ?? 0.0;
+    final parsedReps = double.tryParse(reps.text) ?? 0.0;
+    final computedDuration = (parsedRepDuration > 0 && parsedReps > 0)
+        ? (parsedReps * parsedRepDuration) / 60.0
+        : (int.tryParse(seconds.text) ?? 0) / 60 +
+            (int.tryParse(minutes.text) ?? 0);
+
     final gymSet = widget.gymSet.copyWith(
       name: name,
       unit: unit,
       created: created,
       reps: double.tryParse(reps.text),
+      repDuration: parsedRepDuration,
       weight: double.tryParse(weight.text),
       bodyWeight: double.tryParse(body.text),
       distance: double.tryParse(distance.text),
-      duration:
-          (int.tryParse(seconds.text) ?? 0) / 60 +
-          (int.tryParse(minutes.text) ?? 0),
+      duration: computedDuration,
       cardio: cardio,
       restMs: Value(restMs),
       incline: Value(int.tryParse(incline.text)),
@@ -738,6 +766,7 @@ class _EditSetPageState extends State<EditSetPage> {
     });
 
     if (gymSet.reps != 0) reps.text = toString(gymSet.reps);
+    if (gymSet.repDuration != 0) repDuration.text = toString(gymSet.repDuration);
     weight.text = toString(gymSet.weight);
     setORM();
     if (gymSet.bodyWeight != 0) body.text = toString(gymSet.bodyWeight);

--- a/lib/sets/history_list.dart
+++ b/lib/sets/history_list.dart
@@ -110,7 +110,9 @@ class _HistoryListState extends State<HistoryList> {
     }
 
     String trailing = "$reps x $weight ${gymSet.unit}";
-    if (gymSet.cardio &&
+    if (gymSet.repDuration > 0)
+      trailing = "$reps × ${toString(gymSet.repDuration)}s @ $weight ${gymSet.unit}";
+    else if (gymSet.cardio &&
         (gymSet.unit == 'kg' || gymSet.unit == 'lb' || gymSet.unit == 'stone'))
       trailing = "$weight ${gymSet.unit} / $minutes:$seconds $incline";
     else if (gymSet.cardio &&


### PR DESCRIPTION
### Summary of Changes

This PR adds support for tracking timed-repetition isometric exercises (e.g., Planks, Wall Sits) and multi-rep cadence tracking.

#### Changes Included:
- **Database Schema**: Added `repDuration` column to the `GymSets` table with Drift migration step (`from55To56`) and incremented `schemaVersion` to 56.
- **Set Input Page (`EditSetPage`)**: Added input field for *Time per rep (seconds)*, automatically computing set duration (`reps * repDuration`) when applicable.
- **History List Formatting**: Updated `HistoryList` to format timed-rep sets clearly (e.g., `3 reps × 45s @ 0 kg` for Plank vs `10 x 60 kg` for standard strength exercises).