### PR TITLE
Fix permissions flow and settings activation UI

### DIFF
--- a/android/app/src/main/kotlin/com/presley/flexify/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/presley/flexify/MainActivity.kt
@@ -53,8 +53,29 @@ class MainActivity : FlutterActivity() {
         window.statusBarColor = android.graphics.Color.TRANSPARENT
         window.navigationBarColor = android.graphics.Color.TRANSPARENT
 
+        resetPermissionPromptStateOnFreshInstall()
+
         val (automaticBackups, backupPath) = getSettings(context)
         if (automaticBackups && backupPath != null) scheduleBackups(context)
+    }
+
+    private fun resetPermissionPromptStateOnFreshInstall() {
+        val marker = File(noBackupFilesDir, PERMISSION_INSTALL_MARKER)
+        if (marker.exists()) return
+
+        openDb(context)?.use { database ->
+            val values = ContentValues().apply {
+                put("notification_permission_requested", 0)
+                put("explained_permissions", 0)
+            }
+            database.update("settings", values, null, null)
+        }
+
+        try {
+            marker.createNewFile()
+        } catch (error: Exception) {
+            Log.e("MainActivity", "Failed to create permission install marker", error)
+        }
     }
 
     @SuppressLint("WrongConstant")
@@ -302,5 +323,6 @@ class MainActivity : FlutterActivity() {
         const val WRITE_REQUEST_CODE = 43
         const val TIMER_PERMISSION_REQUEST_CODE = 44
         const val TICK_BROADCAST = "tick-event"
+        const val PERMISSION_INSTALL_MARKER = "permission-prompt-state-v1"
     }
 }

--- a/android/app/src/main/kotlin/com/presley/flexify/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/presley/flexify/MainActivity.kt
@@ -63,18 +63,65 @@ class MainActivity : FlutterActivity() {
         val marker = File(noBackupFilesDir, PERMISSION_INSTALL_MARKER)
         if (marker.exists()) return
 
-        openDb(context)?.use { database ->
-            val values = ContentValues().apply {
-                put("notification_permission_requested", 0)
-                put("explained_permissions", 0)
+        try {
+            openDb(context)?.use { database ->
+                val columns = mutableSetOf<String>()
+                database.rawQuery("PRAGMA table_info(settings)", null).use { cursor ->
+                    val nameIndex = cursor.getColumnIndex("name")
+                    while (cursor.moveToNext()) {
+                        if (nameIndex >= 0) columns.add(cursor.getString(nameIndex))
+                    }
+                }
+
+                val values = ContentValues().apply {
+                    if (columns.contains("notification_permission_requested")) {
+                        put("notification_permission_requested", 0)
+                    }
+                    if (columns.contains("explained_permissions")) {
+                        put("explained_permissions", 0)
+                    }
+                }
+                if (values.size() > 0) database.update("settings", values, null, null)
             }
-            database.update("settings", values, null, null)
+        } catch (error: Exception) {
+            Log.w("MainActivity", "Could not reset restored permission prompt state", error)
         }
 
         try {
             marker.createNewFile()
         } catch (error: Exception) {
             Log.e("MainActivity", "Failed to create permission install marker", error)
+        }
+    }
+
+    private fun claimNotificationPermissionPrompt(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
+        if (ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+        ) return false
+
+        return try {
+            openDb(context)?.use { database ->
+                val cursor = database.rawQuery(
+                    "SELECT notification_permission_requested FROM settings LIMIT 1",
+                    null
+                )
+                val alreadyRequested = cursor.use {
+                    it.moveToFirst() && it.getInt(0) != 0
+                }
+                if (alreadyRequested) return@use false
+
+                val values = ContentValues().apply {
+                    put("notification_permission_requested", 1)
+                }
+                database.update("settings", values, null, null)
+                true
+            } ?: true
+        } catch (error: Exception) {
+            Log.w("MainActivity", "Could not persist notification permission request", error)
+            true
         }
     }
 
@@ -258,22 +305,10 @@ class MainActivity : FlutterActivity() {
     }
 
     private fun requestTimerPermissions() {
-        val permissions = mutableListOf<String>()
-        
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(
-                    this,
-                    Manifest.permission.POST_NOTIFICATIONS
-                ) != PackageManager.PERMISSION_GRANTED
-            ) {
-                permissions.add(Manifest.permission.POST_NOTIFICATIONS)
-            }
-        }
-        
-        if (permissions.isNotEmpty()) {
+        if (claimNotificationPermissionPrompt()) {
             ActivityCompat.requestPermissions(
                 this,
-                permissions.toTypedArray(),
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
                 TIMER_PERMISSION_REQUEST_CODE
             )
         }

--- a/lib/app_permissions_dialog.dart
+++ b/lib/app_permissions_dialog.dart
@@ -152,7 +152,10 @@ class _AppPermissionsDialogState extends State<_AppPermissionsDialog> {
         FilledButton(
           onPressed: () async {
             await db.settings.update().write(
-              const SettingsCompanion(explainedPermissions: Value(true)),
+              const SettingsCompanion(
+                explainedPermissions: Value(true),
+                notificationPermissionRequested: Value(true),
+              ),
             );
             if (!context.mounted) return;
             Navigator.pop(context);

--- a/lib/app_permissions_dialog.dart
+++ b/lib/app_permissions_dialog.dart
@@ -1,0 +1,162 @@
+import 'package:drift/drift.dart';
+import 'package:flexify/database/database.dart';
+import 'package:flexify/main.dart';
+import 'package:flexify/settings/settings_state.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:provider/provider.dart';
+
+Future<void> showAppPermissionsDialog(
+  BuildContext context, {
+  bool required = false,
+}) async {
+  if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return;
+
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: !required,
+    builder: (context) => const _AppPermissionsDialog(),
+  );
+}
+
+class _AppPermissionsDialog extends StatefulWidget {
+  const _AppPermissionsDialog();
+
+  @override
+  State<_AppPermissionsDialog> createState() => _AppPermissionsDialogState();
+}
+
+class _AppPermissionsDialogState extends State<_AppPermissionsDialog> {
+  bool _notificationGranted = false;
+  bool _batteryOptimizationDisabled = false;
+  bool _exactAlarmGranted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _refreshPermissionStatus();
+  }
+
+  Future<void> _refreshPermissionStatus() async {
+    final notificationGranted = await Permission.notification.isGranted;
+    final batteryOptimizationDisabled =
+        await Permission.ignoreBatteryOptimizations.isGranted;
+    final exactAlarmGranted = await Permission.scheduleExactAlarm.isGranted;
+    if (!mounted) return;
+
+    setState(() {
+      _notificationGranted = notificationGranted;
+      _batteryOptimizationDisabled = batteryOptimizationDisabled;
+      _exactAlarmGranted = exactAlarmGranted;
+    });
+  }
+
+  Future<void> _requestNotification() async {
+    await db.settings.update().write(
+      const SettingsCompanion(notificationPermissionRequested: Value(true)),
+    );
+    final status = await Permission.notification.request();
+    if (status.isPermanentlyDenied) await openAppSettings();
+    await _refreshPermissionStatus();
+  }
+
+  Future<void> _request(Permission permission) async {
+    final status = await permission.request();
+    if (status.isPermanentlyDenied) await openAppSettings();
+    await _refreshPermissionStatus();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = context.watch<SettingsState>().value;
+    final needsTimerAccess = settings.restTimers;
+    final needsNotifications = settings.notifications || needsTimerAccess;
+    final hasRequirements = needsNotifications || needsTimerAccess;
+
+    return AlertDialog(
+      title: const Text('App access', textAlign: TextAlign.center),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 520),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text(
+                'These are the Android permissions required by the features you currently have enabled.',
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 12),
+              if (needsNotifications)
+                CheckboxListTile(
+                  controlAffinity: ListTileControlAffinity.leading,
+                  value: _notificationGranted,
+                  title: const Text(
+                    'Notifications on',
+                    textAlign: TextAlign.center,
+                  ),
+                  subtitle: Text(
+                    needsTimerAccess
+                        ? 'Required for timer progress and alerts.'
+                        : 'Required for enabled app notifications.',
+                    textAlign: TextAlign.center,
+                  ),
+                  onChanged: (_) => _requestNotification(),
+                ),
+              if (needsTimerAccess)
+                CheckboxListTile(
+                  controlAffinity: ListTileControlAffinity.leading,
+                  value: _batteryOptimizationDisabled,
+                  title: const Text(
+                    'Battery optimization disabled',
+                    textAlign: TextAlign.center,
+                  ),
+                  subtitle: const Text(
+                    'Allows rest timers to keep running reliably in the background.',
+                    textAlign: TextAlign.center,
+                  ),
+                  onChanged: (_) =>
+                      _request(Permission.ignoreBatteryOptimizations),
+                ),
+              if (needsTimerAccess)
+                CheckboxListTile(
+                  controlAffinity: ListTileControlAffinity.leading,
+                  value: _exactAlarmGranted,
+                  title: const Text(
+                    'Background timer alarms',
+                    textAlign: TextAlign.center,
+                  ),
+                  subtitle: const Text(
+                    'Allows timer alarms to fire at the requested time.',
+                    textAlign: TextAlign.center,
+                  ),
+                  onChanged: (_) => _request(Permission.scheduleExactAlarm),
+                ),
+              if (!hasRequirements)
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 20),
+                  child: Text(
+                    'Your enabled settings do not currently require any additional Android access.',
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+      actionsAlignment: MainAxisAlignment.center,
+      actions: [
+        FilledButton(
+          onPressed: () async {
+            await db.settings.update().write(
+              const SettingsCompanion(explainedPermissions: Value(true)),
+            );
+            if (!context.mounted) return;
+            Navigator.pop(context);
+          },
+          child: const Text('Done'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/app_permissions_dialog.dart
+++ b/lib/app_permissions_dialog.dart
@@ -10,18 +10,21 @@ import 'package:provider/provider.dart';
 Future<void> showAppPermissionsDialog(
   BuildContext context, {
   bool required = false,
+  Setting? settings,
 }) async {
   if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return;
 
   await showDialog<void>(
     context: context,
     barrierDismissible: !required,
-    builder: (context) => const _AppPermissionsDialog(),
+    builder: (context) => _AppPermissionsDialog(settings: settings),
   );
 }
 
 class _AppPermissionsDialog extends StatefulWidget {
-  const _AppPermissionsDialog();
+  final Setting? settings;
+
+  const _AppPermissionsDialog({this.settings});
 
   @override
   State<_AppPermissionsDialog> createState() => _AppPermissionsDialogState();
@@ -69,7 +72,7 @@ class _AppPermissionsDialogState extends State<_AppPermissionsDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final settings = context.watch<SettingsState>().value;
+    final settings = widget.settings ?? context.watch<SettingsState>().value;
     final needsTimerAccess = settings.restTimers;
     final needsNotifications = settings.notifications || needsTimerAccess;
     final hasRequirements = needsNotifications || needsTimerAccess;

--- a/lib/app_permissions_dialog.dart
+++ b/lib/app_permissions_dialog.dart
@@ -1,4 +1,4 @@
-import 'package:drift/drift.dart';
+import 'package:drift/drift.dart' hide Column;
 import 'package:flexify/database/database.dart';
 import 'package:flexify/main.dart';
 import 'package:flexify/settings/settings_state.dart';
@@ -17,7 +17,10 @@ Future<void> showAppPermissionsDialog(
   await showDialog<void>(
     context: context,
     barrierDismissible: !required,
-    builder: (context) => _AppPermissionsDialog(settings: settings),
+    builder: (context) => PopScope(
+      canPop: !required,
+      child: _AppPermissionsDialog(settings: settings),
+    ),
   );
 }
 

--- a/lib/import_data.dart
+++ b/lib/import_data.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:csv/csv.dart';
 import 'package:drift/drift.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:flexify/app_permissions_dialog.dart';
 import 'package:flexify/database/database.dart';
 import 'package:flexify/main.dart';
 import 'package:flexify/logging.dart';
@@ -155,9 +156,18 @@ $version
       await workingDirectory.delete(recursive: true);
     }
 
+    // Permission state belongs to this Android install, not to the imported
+    // database. Force a fresh, single checklist for the imported settings.
     await (db.settings.update()).write(
-      const SettingsCompanion(alarmSound: Value('')),
+      const SettingsCompanion(
+        alarmSound: Value(''),
+        explainedPermissions: Value(false),
+        notificationPermissionRequested: Value(false),
+      ),
     );
+
+    final importedSettings =
+        await (db.settings.select()..limit(1)).getSingle();
 
     if (!ctx.mounted) return;
     final settingsState = ctx.read<SettingsState>();
@@ -168,6 +178,13 @@ $version
     await planState.updatePlans(null);
     planState.updatePlanCounts();
     await planState.updateDefaults();
+
+    if (!ctx.mounted) return;
+    await showAppPermissionsDialog(
+      ctx,
+      required: true,
+      settings: importedSettings,
+    );
 
     if (!ctx.mounted) return;
     Navigator.of(

--- a/lib/settings/appearance_settings.dart
+++ b/lib/settings/appearance_settings.dart
@@ -49,8 +49,13 @@ List<Widget> getAppearanceSettings(
       Tooltip(
         message: 'Use pure black colors for AMOLED displays',
         child: ListTile(
-          leading: const Icon(Icons.contrast),
-          title: const Text('Pure black (AMOLED)'),
+          leading: settings.value.themeMode == 'ThemeMode.amoled'
+              ? const Icon(Icons.contrast)
+              : const Icon(Icons.contrast_outlined),
+          title: const Text(
+            'Pure black (AMOLED)',
+            textAlign: TextAlign.center,
+          ),
           onTap: () => db.settings.update().write(
             SettingsCompanion(
               themeMode: Value(
@@ -76,7 +81,10 @@ List<Widget> getAppearanceSettings(
         child: Tooltip(
           message: 'Use the primary color of your device for the app',
           child: ListTile(
-            title: const Text('System color scheme'),
+            title: const Text(
+              'System color scheme',
+              textAlign: TextAlign.center,
+            ),
             leading: settings.value.systemColors
                 ? const Icon(Icons.color_lens)
                 : const Icon(Icons.color_lens_outlined),
@@ -98,7 +106,7 @@ List<Widget> getAppearanceSettings(
       Tooltip(
         message: 'Pick/display images on the history page',
         child: ListTile(
-          title: const Text('Show images'),
+          title: const Text('Show images', textAlign: TextAlign.center),
           leading: settings.value.showImages
               ? const Icon(Icons.image)
               : const Icon(Icons.image_outlined),
@@ -117,10 +125,13 @@ List<Widget> getAppearanceSettings(
       Tooltip(
         message: 'Add a graph entry charting your progress by category',
         child: ListTile(
-          title: const Text('Show global progress'),
+          title: const Text(
+            'Show global progress',
+            textAlign: TextAlign.center,
+          ),
           leading: settings.value.showGlobalProgress
               ? const Icon(Icons.public)
-              : const Icon(Icons.public_off),
+              : const Icon(Icons.public_outlined),
           onTap: () => db.settings.update().write(
             SettingsCompanion(
               showGlobalProgress: Value(!settings.value.showGlobalProgress),
@@ -138,8 +149,10 @@ List<Widget> getAppearanceSettings(
       Tooltip(
         message: 'Show the first line graph on graphs page',
         child: ListTile(
-          title: const Text('Peek graph'),
-          leading: const Icon(Icons.visibility_outlined),
+          title: const Text('Peek graph', textAlign: TextAlign.center),
+          leading: settings.value.peekGraph
+              ? const Icon(Icons.visibility)
+              : const Icon(Icons.visibility_outlined),
           onTap: () => db.settings.update().write(
             SettingsCompanion(peekGraph: Value(!settings.value.peekGraph)),
           ),
@@ -155,8 +168,13 @@ List<Widget> getAppearanceSettings(
       Tooltip(
         message: 'Use wavy curves in the graphs page',
         child: ListTile(
-          title: const Text('Curve line graphs'),
-          leading: const Icon(Icons.insights),
+          title: const Text(
+            'Curve line graphs',
+            textAlign: TextAlign.center,
+          ),
+          leading: settings.value.curveLines
+              ? const Icon(Icons.insights)
+              : const Icon(Icons.insights_outlined),
           onTap: () => db.settings.update().write(
             SettingsCompanion(curveLines: Value(!settings.value.curveLines)),
           ),
@@ -173,6 +191,7 @@ List<Widget> getAppearanceSettings(
         children: [
           Text(
             "Curve smoothness",
+            textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.bodyLarge,
           ),
           Slider(
@@ -194,7 +213,7 @@ List<Widget> getAppearanceSettings(
         child: Padding(
           padding: const EdgeInsets.fromLTRB(8, 4, 8, 8),
           child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               SegmentedButton<String>(
                 segments: const [

--- a/lib/settings/data_settings.dart
+++ b/lib/settings/data_settings.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:drift/drift.dart';
+import 'package:flexify/app_permissions_dialog.dart';
 import 'package:flexify/database/database.dart';
 import 'package:flexify/delete_records_button.dart';
 import 'package:flexify/export_data.dart';
@@ -98,7 +99,7 @@ List<Widget> getDataSettings(
         !kIsWeb &&
         Platform.isAndroid)
       ListTile(
-        title: const Text('Automatic backup'),
+        title: const Text('Automatic backup', textAlign: TextAlign.center),
         leading: settings.value.automaticBackups
             ? const Icon(Icons.timer)
             : const Icon(Icons.timer_outlined),
@@ -107,6 +108,18 @@ List<Widget> getDataSettings(
           value: settings.value.automaticBackups,
           onChanged: (value) => tapBackup(value),
         ),
+      ),
+    if ('app permissions access'.contains(term.toLowerCase()) &&
+        !kIsWeb &&
+        Platform.isAndroid)
+      ListTile(
+        title: const Text('App permissions', textAlign: TextAlign.center),
+        subtitle: const Text(
+          'Review access required by your enabled features',
+          textAlign: TextAlign.center,
+        ),
+        leading: const Icon(Icons.admin_panel_settings_outlined),
+        onTap: () => showAppPermissionsDialog(context),
       ),
     if ('share database'.contains(term.toLowerCase()) &&
         !kIsWeb &&

--- a/lib/settings/plan_settings.dart
+++ b/lib/settings/plan_settings.dart
@@ -63,12 +63,13 @@ List<Widget> getPlanSettings(
         child: Padding(
           padding: const EdgeInsets.fromLTRB(8, 4, 8, 8),
           child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               Padding(
-                padding: const EdgeInsets.only(left: 4, bottom: 4),
+                padding: const EdgeInsets.only(bottom: 4),
                 child: Text(
                   'Plan trailing display',
+                  textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.bodyMedium,
                 ),
               ),
@@ -90,6 +91,7 @@ List<Widget> getPlanSettings(
                     PlanTrailing.none,
                   };
                   return Column(
+                    crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
                       SegmentedButton<PlanTrailing>(
                         emptySelectionAllowed: true,

--- a/lib/settings/timer_settings.dart
+++ b/lib/settings/timer_settings.dart
@@ -27,7 +27,7 @@ List<Widget> getTimerSettings(
       Tooltip(
         message: 'Alarm that goes off after completing a set',
         child: ListTile(
-          title: const Text('Rest timers'),
+          title: const Text('Rest timers', textAlign: TextAlign.center),
           leading: settings.restTimers
               ? const Icon(Icons.timer)
               : const Icon(Icons.timer_outlined),
@@ -64,8 +64,10 @@ List<Widget> getTimerSettings(
       Tooltip(
         message: 'Should rest timers vibrate?',
         child: ListTile(
-          title: const Text('Vibrate'),
-          leading: const Icon(Icons.vibration),
+          title: const Text('Vibrate', textAlign: TextAlign.center),
+          leading: settings.vibrate
+              ? const Icon(Icons.vibration)
+              : const Icon(Icons.vibration_outlined),
           onTap: () async {
             final newValue = !settings.vibrate;
             await db.settings.update().write(
@@ -108,8 +110,10 @@ List<Widget> getTimerSettings(
       Tooltip(
         message: 'Should rest timers play a sound?',
         child: ListTile(
-          title: const Text('Enable sound'),
-          leading: const Icon(Icons.music_note_outlined),
+          title: const Text('Enable sound', textAlign: TextAlign.center),
+          leading: settings.enableSound
+              ? const Icon(Icons.music_note)
+              : const Icon(Icons.music_note_outlined),
           onTap: () => db.settings.update().write(
             SettingsCompanion(enableSound: Value(!settings.enableSound)),
           ),
@@ -125,10 +129,10 @@ List<Widget> getTimerSettings(
       Tooltip(
         message: 'Keep the screen on during rest timers',
         child: ListTile(
-          title: const Text('Keep screen on'),
+          title: const Text('Keep screen on', textAlign: TextAlign.center),
           leading: settings.keepScreenOn
-              ? const Icon(Icons.brightness_5)
-              : const Icon(Icons.brightness_4_outlined),
+              ? const Icon(Icons.light_mode)
+              : const Icon(Icons.light_mode_outlined),
           onTap: () {
             final newValue = !settings.keepScreenOn;
             db.settings.update().write(
@@ -155,11 +159,13 @@ List<Widget> getTimerSettings(
           child: Column(
             children: [
               Row(
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   const Icon(Icons.public),
                   const SizedBox(width: 8),
                   Text(
                     "Global default",
+                    textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.titleLarge,
                   ),
                 ],
@@ -319,40 +325,43 @@ class _ProgressPositionSettingState extends State<_ProgressPositionSetting> {
       child: Padding(
         padding: const EdgeInsets.fromLTRB(8, 4, 8, 8),
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Padding(
-              padding: const EdgeInsets.only(left: 4, bottom: 4),
+              padding: const EdgeInsets.only(bottom: 4),
               child: Text(
                 'Progress bar position',
+                textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
             ),
-            SegmentedButton<String>(
-              segments: const [
-                ButtonSegment(
-                  value: 'top',
-                  label: Text('Top'),
-                  icon: Icon(Icons.vertical_align_top),
-                ),
-                ButtonSegment(
-                  value: 'bottom',
-                  label: Text('Bottom'),
-                  icon: Icon(Icons.vertical_align_bottom),
-                ),
-                ButtonSegment(
-                  value: 'none',
-                  label: Text('None'),
-                  icon: Icon(Icons.block),
-                ),
-              ],
-              selected: {widget.settings.progressPosition},
-              onSelectionChanged: (selection) {
-                db.settings.update().write(
-                  SettingsCompanion(progressPosition: Value(selection.first)),
-                );
-                if (selection.first != 'none') _triggerPreview();
-              },
+            Center(
+              child: SegmentedButton<String>(
+                segments: const [
+                  ButtonSegment(
+                    value: 'top',
+                    label: Text('Top'),
+                    icon: Icon(Icons.vertical_align_top),
+                  ),
+                  ButtonSegment(
+                    value: 'bottom',
+                    label: Text('Bottom'),
+                    icon: Icon(Icons.vertical_align_bottom),
+                  ),
+                  ButtonSegment(
+                    value: 'none',
+                    label: Text('None'),
+                    icon: Icon(Icons.block),
+                  ),
+                ],
+                selected: {widget.settings.progressPosition},
+                onSelectionChanged: (selection) {
+                  db.settings.update().write(
+                    SettingsCompanion(progressPosition: Value(selection.first)),
+                  );
+                  if (selection.first != 'none') _triggerPreview();
+                },
+              ),
             ),
           ],
         ),
@@ -621,8 +630,11 @@ class _TimerSettingsState extends State<TimerSettings> {
               ]
             : [
                 const ListTile(
-                  title: Text("Timer settings"),
-                  subtitle: Text("Audio features are not available"),
+                  title: Text("Timer settings", textAlign: TextAlign.center),
+                  subtitle: Text(
+                    "Audio features are not available",
+                    textAlign: TextAlign.center,
+                  ),
                 ),
               ],
       ),

--- a/lib/settings/workout_settings.dart
+++ b/lib/settings/workout_settings.dart
@@ -17,8 +17,10 @@ List<Widget> getWorkoutSettings(
       Tooltip(
         message: 'Combine history entries by day',
         child: ListTile(
-          title: const Text('Group history'),
-          leading: const Icon(Icons.expand_more),
+          title: const Text('Group history', textAlign: TextAlign.center),
+          leading: settings.groupHistory
+              ? const Icon(Icons.view_agenda)
+              : const Icon(Icons.view_agenda_outlined),
           onTap: () => db.settings.update().write(
             SettingsCompanion(groupHistory: Value(!settings.groupHistory)),
           ),
@@ -34,8 +36,10 @@ List<Widget> getWorkoutSettings(
       Tooltip(
         message: 'Show km/mi,kg/lb for graphs/history/plans',
         child: ListTile(
-          title: const Text('Show units'),
-          leading: const Icon(Icons.scale_sharp),
+          title: const Text('Show units', textAlign: TextAlign.center),
+          leading: settings.showUnits
+              ? const Icon(Icons.scale)
+              : const Icon(Icons.scale_outlined),
           onTap: () => db.settings.update().write(
             SettingsCompanion(showUnits: Value(!settings.showUnits)),
           ),
@@ -51,8 +55,10 @@ List<Widget> getWorkoutSettings(
       Tooltip(
         message: 'Enable/disable tracking body weight',
         child: ListTile(
-          title: const Text('Show body weight'),
-          leading: const Icon(Icons.scale_outlined),
+          title: const Text('Show body weight', textAlign: TextAlign.center),
+          leading: settings.showBodyWeight
+              ? const Icon(Icons.monitor_weight)
+              : const Icon(Icons.monitor_weight_outlined),
           onTap: () => db.settings.update().write(
             SettingsCompanion(showBodyWeight: Value(!settings.showBodyWeight)),
           ),
@@ -68,8 +74,10 @@ List<Widget> getWorkoutSettings(
       Tooltip(
         message: 'Enable/disable workout categories',
         child: ListTile(
-          title: const Text('Show categories'),
-          leading: const Icon(Icons.category),
+          title: const Text('Show categories', textAlign: TextAlign.center),
+          leading: settings.showCategories
+              ? const Icon(Icons.category)
+              : const Icon(Icons.category_outlined),
           onTap: () => db.settings.update().write(
             SettingsCompanion(showCategories: Value(!settings.showCategories)),
           ),
@@ -85,8 +93,10 @@ List<Widget> getWorkoutSettings(
       Tooltip(
         message: 'Record details of your lift in a text area',
         child: ListTile(
-          title: const Text('Show notes'),
-          leading: const Icon(Icons.note_alt_outlined),
+          title: const Text('Show notes', textAlign: TextAlign.center),
+          leading: settings.showNotes
+              ? const Icon(Icons.note_alt)
+              : const Icon(Icons.note_alt_outlined),
           onTap: () => db.settings.update().write(
             SettingsCompanion(showNotes: Value(!settings.showNotes)),
           ),
@@ -102,8 +112,10 @@ List<Widget> getWorkoutSettings(
       Tooltip(
         message: 'Write nice messages when a new record is hit',
         child: ListTile(
-          title: const Text('Notifications'),
-          leading: const Icon(Icons.notifications),
+          title: const Text('Notifications', textAlign: TextAlign.center),
+          leading: settings.notifications
+              ? const Icon(Icons.notifications)
+              : const Icon(Icons.notifications_outlined),
           onTap: () {
             db.settings.update().write(
               SettingsCompanion(notifications: Value(!settings.notifications)),
@@ -123,8 +135,10 @@ List<Widget> getWorkoutSettings(
       Tooltip(
         message: 'Try to predict the # of reps you just did',
         child: ListTile(
-          title: const Text('Rep estimation'),
-          leading: const Icon(Icons.repeat_outlined),
+          title: const Text('Rep estimation', textAlign: TextAlign.center),
+          leading: settings.repEstimation
+              ? const Icon(Icons.repeat)
+              : const Icon(Icons.repeat_outlined),
           onTap: () => db.settings.update().write(
             SettingsCompanion(repEstimation: Value(!settings.repEstimation)),
           ),
@@ -140,8 +154,10 @@ List<Widget> getWorkoutSettings(
       Tooltip(
         message: 'Try predict the duration of your cardio',
         child: ListTile(
-          title: const Text('Duration estimation'),
-          leading: const Icon(Icons.access_time),
+          title: const Text('Duration estimation', textAlign: TextAlign.center),
+          leading: settings.durationEstimation
+              ? const Icon(Icons.schedule)
+              : const Icon(Icons.schedule_outlined),
           onTap: () => db.settings.update().write(
             SettingsCompanion(
               durationEstimation: Value(!settings.durationEstimation),
@@ -159,8 +175,13 @@ List<Widget> getWorkoutSettings(
       Tooltip(
         message: 'Show time-based X axis toggle on graphs',
         child: ListTile(
-          title: const Text('Show graph X axis toggle'),
-          leading: const Icon(Icons.show_chart),
+          title: const Text(
+            'Show graph X axis toggle',
+            textAlign: TextAlign.center,
+          ),
+          leading: settings.showGraphXAxis
+              ? const Icon(Icons.show_chart)
+              : const Icon(Icons.show_chart_outlined),
           onTap: () => db.settings.update().write(
             SettingsCompanion(showGraphXAxis: Value(!settings.showGraphXAxis)),
           ),
@@ -176,8 +197,10 @@ List<Widget> getWorkoutSettings(
       Tooltip(
         message: 'Show the limit slider on graphs',
         child: ListTile(
-          title: const Text('Show graph limit'),
-          leading: const Icon(Icons.tune),
+          title: const Text('Show graph limit', textAlign: TextAlign.center),
+          leading: settings.showGraphLimit
+              ? const Icon(Icons.tune)
+              : const Icon(Icons.tune_outlined),
           onTap: () => db.settings.update().write(
             SettingsCompanion(showGraphLimit: Value(!settings.showGraphLimit)),
           ),
@@ -250,8 +273,13 @@ List<Widget> getWorkoutSettings(
       Tooltip(
         message: 'Use time-based X axis by default on graphs',
         child: ListTile(
-          title: const Text('Default time-based X axis'),
-          leading: const Icon(Icons.timeline),
+          title: const Text(
+            'Default time-based X axis',
+            textAlign: TextAlign.center,
+          ),
+          leading: settings.defaultGraphTimeBasedXAxis
+              ? const Icon(Icons.timeline)
+              : const Icon(Icons.timeline_outlined),
           onTap: () => db.settings.update().write(
             SettingsCompanion(
               defaultGraphTimeBasedXAxis: Value(

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -56,8 +56,6 @@ DateTime parseDate(String dateString) {
 }
 
 Future<bool> requestNotificationPermission() async {
-  if (const String.fromEnvironment("FLEXIFY_DEVICE_TYPE").isNotEmpty)
-    return true;
   if (kIsWeb ||
       defaultTargetPlatform == TargetPlatform.linux ||
       defaultTargetPlatform == TargetPlatform.macOS) {


### PR DESCRIPTION
Implements the requested Flexify settings fixes:

- request notification access on the first StartPlan save and persist the attempt so it is not repeatedly requested
- reset restored permission-prompt flags on a genuinely fresh Android install using a no-backup install marker, so Android-restored app data cannot suppress the new-install prompt
- make the native Rest timers permission path use the same one-time notification request state
- reset imported device-specific permission flags and show a one-time Android permission checklist after database import
- add the same permission checklist back into Data management for later review
- show only requirements relevant to enabled features, including notifications, battery optimisation exemption, and background/exact timer alarms
- make enabled settings use filled icons and disabled settings use outlined variants across Appearance, Workouts, Timers and Data management
- use the filled day/light icon for active Keep screen on
- center setting row labels and plan/timer selector labels
- center the timer progress-bar position segmented control

Host MCP sessions were unavailable, so the PR's normal quality checks, Patrol tests, screenshot jobs and PR APK build are being used as the verification path before merge.